### PR TITLE
Add twostage fallback

### DIFF
--- a/data/core/chitchat.md
+++ b/data/core/chitchat.md
@@ -48,7 +48,7 @@
     - utter_confirmationemail
     - utter_docu
     - utter_ask_feedback
-* mood_confirm
+* affirm
     - utter_thumbsup
     - utter_anything_else
 
@@ -70,7 +70,7 @@
     - utter_confirmationemail
     - utter_docu
     - utter_ask_feedback
-* mood_confirm
+* affirm
     - utter_thumbsup
     - utter_anything_else
 
@@ -88,7 +88,7 @@
     - utter_confirmationemail
     - utter_docu
     - utter_ask_feedback
-* mood_confirm
+* affirm
     - utter_thumbsup
     - utter_anything_else
 
@@ -120,7 +120,7 @@
     - utter_already_subscribed
     - utter_docu
     - utter_ask_feedback
-* mood_confirm
+* affirm
     - utter_thumbsup
     - utter_anything_else
 
@@ -154,7 +154,7 @@
     - utter_already_subscribed
     - utter_docu
     - utter_ask_feedback
-* mood_confirm
+* affirm
     - utter_thumbsup
     - utter_anything_else
 
@@ -175,7 +175,7 @@
     - utter_already_subscribed
     - utter_docu
     - utter_ask_feedback
-* mood_confirm
+* affirm
     - utter_thumbsup
     - utter_anything_else
 
@@ -535,21 +535,21 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm
+* affirm
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
-* mood_confirm
+* affirm
     - utter_ask_migration
 * deny
     - utter_explain_stack
     - utter_stack_details
     - utter_explain_nlucore
-* mood_confirm OR how_to_get_started{"product":"stack"}
+* affirm OR how_to_get_started{"product":"stack"}
     - utter_explain_nlu
     - utter_explain_core
     - utter_tryout
-* how_to_get_started{"product":"core"} OR mood_confirm OR how_to_get_started{"product":"stack"}
+* how_to_get_started{"product":"core"} OR affirm OR how_to_get_started{"product":"stack"}
     - utter_quickstart
     - utter_anything_else
 
@@ -563,21 +563,21 @@
 * ask_weather OR ask_builder OR ask_howdoing OR ask_whoisit OR ask_whatisrasa OR ask_isbot OR ask_howold OR ask_languagesbot OR ask_restaurant OR ask_time OR ask_wherefrom OR ask_whoami OR handleinsult OR nicetomeeyou OR telljoke OR ask_whatismyname OR howwereyoubuilt
     - action_chitchat
     - utter_first_bot_with_rasa
-* mood_confirm
+* affirm
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
-* mood_confirm
+* affirm
     - utter_ask_migration
 * deny
     - utter_explain_stack
     - utter_stack_details
     - utter_explain_nlucore
-* mood_confirm OR how_to_get_started{"product":"stack"}
+* affirm OR how_to_get_started{"product":"stack"}
     - utter_explain_nlu
     - utter_explain_core
     - utter_tryout
-* how_to_get_started{"product":"core"} OR mood_confirm OR how_to_get_started{"product":"stack"}
+* how_to_get_started{"product":"core"} OR affirm OR how_to_get_started{"product":"stack"}
     - utter_quickstart
     - utter_anything_else
 
@@ -588,24 +588,24 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm
+* affirm
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
 * ask_weather OR ask_builder OR ask_howdoing OR ask_whoisit OR ask_whatisrasa OR ask_isbot OR ask_howold OR ask_languagesbot OR ask_restaurant OR ask_time OR ask_wherefrom OR ask_whoami OR handleinsult OR nicetomeeyou OR telljoke OR ask_whatismyname OR howwereyoubuilt
     - action_chitchat
     - utter_built_bot_before
-* mood_confirm
+* affirm
     - utter_ask_migration
 * deny
     - utter_explain_stack
     - utter_stack_details
     - utter_explain_nlucore
-* mood_confirm OR how_to_get_started{"product":"stack"}
+* affirm OR how_to_get_started{"product":"stack"}
     - utter_explain_nlu
     - utter_explain_core
     - utter_tryout
-* how_to_get_started{"product":"core"} OR mood_confirm OR how_to_get_started{"product":"stack"}
+* how_to_get_started{"product":"core"} OR affirm OR how_to_get_started{"product":"stack"}
     - utter_quickstart
     - utter_anything_else
 
@@ -615,11 +615,11 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm
+* affirm
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
-* mood_confirm
+* affirm
     - utter_ask_migration
 * ask_weather OR ask_builder OR ask_howdoing OR ask_whoisit OR ask_whatisrasa OR ask_isbot OR ask_howold OR ask_languagesbot OR ask_restaurant OR ask_time OR ask_wherefrom OR ask_whoami OR handleinsult OR nicetomeeyou OR telljoke OR ask_whatismyname OR howwereyoubuilt
     - action_chitchat
@@ -628,11 +628,11 @@
     - utter_explain_stack
     - utter_stack_details
     - utter_explain_nlucore
-* mood_confirm OR how_to_get_started{"product":"stack"}
+* affirm OR how_to_get_started{"product":"stack"}
     - utter_explain_nlu
     - utter_explain_core
     - utter_tryout
-* how_to_get_started{"product":"core"} OR mood_confirm OR how_to_get_started{"product":"stack"}
+* how_to_get_started{"product":"core"} OR affirm OR how_to_get_started{"product":"stack"}
     - utter_quickstart
     - utter_anything_else
 
@@ -642,11 +642,11 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm
+* affirm
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
-* mood_confirm
+* affirm
     - utter_ask_migration
 * deny
     - utter_explain_stack
@@ -655,11 +655,11 @@
 * ask_weather OR ask_builder OR ask_howdoing OR ask_whoisit OR ask_whatisrasa OR ask_isbot OR ask_howold OR ask_languagesbot OR ask_restaurant OR ask_time OR ask_wherefrom OR ask_whoami OR handleinsult OR nicetomeeyou OR telljoke OR ask_whatismyname OR howwereyoubuilt
     - action_chitchat
     - utter_explain_nlucore
-* mood_confirm OR how_to_get_started{"product":"stack"}
+* affirm OR how_to_get_started{"product":"stack"}
     - utter_explain_nlu
     - utter_explain_core
     - utter_tryout
-* how_to_get_started{"product":"core"} OR mood_confirm OR how_to_get_started{"product":"stack"}
+* how_to_get_started{"product":"core"} OR affirm OR how_to_get_started{"product":"stack"}
     - utter_quickstart
     - utter_anything_else
 
@@ -669,24 +669,24 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm
+* affirm
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
-* mood_confirm
+* affirm
     - utter_ask_migration
 * deny
     - utter_explain_stack
     - utter_stack_details
     - utter_explain_nlucore
-* mood_confirm OR how_to_get_started{"product":"stack"}
+* affirm OR how_to_get_started{"product":"stack"}
     - utter_explain_nlu
     - utter_explain_core
     - utter_tryout
 * ask_weather OR ask_builder OR ask_howdoing OR ask_whoisit OR ask_whatisrasa OR ask_isbot OR ask_howold OR ask_languagesbot OR ask_restaurant OR ask_time OR ask_wherefrom OR ask_whoami OR handleinsult OR nicetomeeyou OR telljoke OR ask_whatismyname OR howwereyoubuilt
     - action_chitchat
     - utter_tryout
-* how_to_get_started{"product":"core"} OR mood_confirm OR how_to_get_started{"product":"stack"}
+* how_to_get_started{"product":"core"} OR affirm OR how_to_get_started{"product":"stack"}
     - utter_quickstart
     - utter_anything_else
 
@@ -697,7 +697,7 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm
+* affirm
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
@@ -708,11 +708,11 @@
     - utter_explain_stack
     - utter_stack_details
     - utter_explain_nlucore
-* mood_confirm OR how_to_get_started{"product":"stack"}
+* affirm OR how_to_get_started{"product":"stack"}
     - utter_explain_nlu
     - utter_explain_core
     - utter_tryout
-* how_to_get_started{"product":"core"} OR mood_confirm OR how_to_get_started{"product":"stack"}
+* how_to_get_started{"product":"core"} OR affirm OR how_to_get_started{"product":"stack"}
     - utter_quickstart
     - utter_anything_else
 
@@ -722,7 +722,7 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm
+* affirm
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
@@ -733,11 +733,11 @@
 * ask_weather OR ask_builder OR ask_howdoing OR ask_whoisit OR ask_whatisrasa OR ask_isbot OR ask_howold OR ask_languagesbot OR ask_restaurant OR ask_time OR ask_wherefrom OR ask_whoami OR handleinsult OR nicetomeeyou OR telljoke OR ask_whatismyname OR howwereyoubuilt
     - action_chitchat
     - utter_explain_nlucore
-* mood_confirm OR how_to_get_started{"product":"stack"}
+* affirm OR how_to_get_started{"product":"stack"}
     - utter_explain_nlu
     - utter_explain_core
     - utter_tryout
-* how_to_get_started{"product":"core"} OR mood_confirm OR how_to_get_started{"product":"stack"}
+* how_to_get_started{"product":"core"} OR affirm OR how_to_get_started{"product":"stack"}
     - utter_quickstart
     - utter_anything_else
 
@@ -747,7 +747,7 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm
+* affirm
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
@@ -755,14 +755,14 @@
     - utter_explain_stack
     - utter_stack_details
     - utter_explain_nlucore
-* mood_confirm OR how_to_get_started{"product":"stack"}
+* affirm OR how_to_get_started{"product":"stack"}
     - utter_explain_nlu
     - utter_explain_core
     - utter_tryout
 * ask_weather OR ask_builder OR ask_howdoing OR ask_whoisit OR ask_whatisrasa OR ask_isbot OR ask_howold OR ask_languagesbot OR ask_restaurant OR ask_time OR ask_wherefrom OR ask_whoami OR handleinsult OR nicetomeeyou OR telljoke OR ask_whatismyname OR howwereyoubuilt
     - action_chitchat
     - utter_tryout
-* how_to_get_started{"product":"core"} OR mood_confirm OR how_to_get_started{"product":"stack"}
+* how_to_get_started{"product":"core"} OR affirm OR how_to_get_started{"product":"stack"}
     - utter_quickstart
     - utter_anything_else
 
@@ -772,7 +772,7 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm
+* affirm
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
@@ -788,7 +788,7 @@
     - utter_also_explain_nlu
 * deny
     - utter_tryout
-* how_to_get_started{"product":"core"} OR mood_confirm OR how_to_get_started{"product":"stack"}
+* how_to_get_started{"product":"core"} OR affirm OR how_to_get_started{"product":"stack"}
     - utter_quickstart
     - utter_anything_else
 
@@ -798,7 +798,7 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm
+* affirm
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
@@ -814,7 +814,7 @@
 * ask_weather OR ask_builder OR ask_howdoing OR ask_whoisit OR ask_whatisrasa OR ask_isbot OR ask_howold OR ask_languagesbot OR ask_restaurant OR ask_time OR ask_wherefrom OR ask_whoami OR handleinsult OR nicetomeeyou OR telljoke OR ask_whatismyname OR howwereyoubuilt
     - action_chitchat
     - utter_tryout
-* how_to_get_started{"product":"core"} OR mood_confirm OR how_to_get_started{"product":"stack"}
+* how_to_get_started{"product":"core"} OR affirm OR how_to_get_started{"product":"stack"}
     - utter_quickstart
     - utter_anything_else
 
@@ -825,7 +825,7 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm
+* affirm
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
@@ -839,10 +839,10 @@
 * ask_weather OR ask_builder OR ask_howdoing OR ask_whoisit OR ask_whatisrasa OR ask_isbot OR ask_howold OR ask_languagesbot OR ask_restaurant OR ask_time OR ask_wherefrom OR ask_whoami OR handleinsult OR nicetomeeyou OR telljoke OR ask_whatismyname OR howwereyoubuilt
     - action_chitchat
     - utter_also_explain_nlu
-* mood_confirm
+* affirm
     - utter_explain_nlu
     - utter_tryout
-* how_to_get_started{"product":"core"} OR mood_confirm OR how_to_get_started{"product":"stack"}
+* how_to_get_started{"product":"core"} OR affirm OR how_to_get_started{"product":"stack"}
     - utter_quickstart
     - utter_anything_else
 
@@ -852,7 +852,7 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm
+* affirm
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
@@ -863,13 +863,13 @@
 * how_to_get_started{"product": "core"}
     - utter_explain_core
     - utter_also_explain_nlu
-* mood_confirm
+* affirm
     - utter_explain_nlu
     - utter_tryout
 * ask_weather OR ask_builder OR ask_howdoing OR ask_whoisit OR ask_whatisrasa OR ask_isbot OR ask_howold OR ask_languagesbot OR ask_restaurant OR ask_time OR ask_wherefrom OR ask_whoami OR handleinsult OR nicetomeeyou OR telljoke OR ask_whatismyname OR howwereyoubuilt
     - action_chitchat
     - utter_tryout
-* how_to_get_started{"product":"core"} OR mood_confirm OR how_to_get_started{"product":"stack"}
+* how_to_get_started{"product":"core"} OR affirm OR how_to_get_started{"product":"stack"}
     - utter_quickstart
     - utter_anything_else
 
@@ -880,7 +880,7 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm
+* affirm
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
@@ -896,7 +896,7 @@
     - utter_also_explain_core
 * deny
     - utter_tryout
-* how_to_get_started{"product":"core"} OR mood_confirm OR how_to_get_started{"product":"stack"}
+* how_to_get_started{"product":"core"} OR affirm OR how_to_get_started{"product":"stack"}
     - utter_quickstart
     - utter_anything_else
 
@@ -906,7 +906,7 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm
+* affirm
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
@@ -922,7 +922,7 @@
 * ask_weather OR ask_builder OR ask_howdoing OR ask_whoisit OR ask_whatisrasa OR ask_isbot OR ask_howold OR ask_languagesbot OR ask_restaurant OR ask_time OR ask_wherefrom OR ask_whoami OR handleinsult OR nicetomeeyou OR telljoke OR ask_whatismyname OR howwereyoubuilt
     - action_chitchat
     - utter_tryout
-* how_to_get_started{"product":"core"} OR mood_confirm OR how_to_get_started{"product":"stack"}
+* how_to_get_started{"product":"core"} OR affirm OR how_to_get_started{"product":"stack"}
     - utter_quickstart
     - utter_anything_else
 
@@ -933,7 +933,7 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm
+* affirm
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
@@ -946,7 +946,7 @@
     - utter_explain_nlucore
 * deny
     - utter_tryout
-* how_to_get_started{"product":"core"} OR mood_confirm OR how_to_get_started{"product":"stack"}
+* how_to_get_started{"product":"core"} OR affirm OR how_to_get_started{"product":"stack"}
     - utter_quickstart
     - utter_anything_else
 
@@ -956,7 +956,7 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm
+* affirm
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
@@ -969,7 +969,7 @@
 * ask_weather OR ask_builder OR ask_howdoing OR ask_whoisit OR ask_whatisrasa OR ask_isbot OR ask_howold OR ask_languagesbot OR ask_restaurant OR ask_time OR ask_wherefrom OR ask_whoami OR handleinsult OR nicetomeeyou OR telljoke OR ask_whatismyname OR howwereyoubuilt
     - action_chitchat
     - utter_tryout
-* how_to_get_started{"product":"core"} OR mood_confirm OR how_to_get_started{"product":"stack"}
+* how_to_get_started{"product":"core"} OR affirm OR how_to_get_started{"product":"stack"}
     - utter_quickstart
     - utter_anything_else
 
@@ -980,7 +980,7 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm
+* affirm
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
@@ -988,7 +988,7 @@
     - utter_explain_stack
     - utter_stack_details
     - utter_explain_nlucore
-* mood_confirm OR how_to_get_started{"product":"stack"}
+* affirm OR how_to_get_started{"product":"stack"}
     - utter_explain_nlu
     - utter_explain_core
     - utter_tryout
@@ -1128,7 +1128,7 @@
 * nlu_info{"nlu_part": "intent classification"}
     - utter_nlu_intent_tutorial
     - utter_offer_recommendation
-* pipeline_recommendation OR mood_confirm
+* pipeline_recommendation OR affirm
     - utter_what_language
 * ask_weather OR ask_builder OR ask_howdoing OR ask_whoisit OR ask_whatisrasa OR ask_isbot OR ask_howold OR ask_languagesbot OR ask_restaurant OR ask_time OR ask_wherefrom OR ask_whoami OR handleinsult OR nicetomeeyou OR telljoke OR ask_whatismyname OR howwereyoubuilt
     - action_chitchat
@@ -1154,7 +1154,7 @@
 * nlu_info{"nlu_part": "intent classification"}
     - utter_nlu_intent_tutorial
     - utter_offer_recommendation
-* pipeline_recommendation OR mood_confirm
+* pipeline_recommendation OR affirm
     - utter_what_language
 * ask_weather OR ask_builder OR ask_howdoing OR ask_whoisit OR ask_whatisrasa OR ask_isbot OR ask_howold OR ask_languagesbot OR ask_restaurant OR ask_time OR ask_wherefrom OR ask_whoami OR handleinsult OR nicetomeeyou OR telljoke OR ask_whatismyname OR howwereyoubuilt
     - action_chitchat
@@ -1184,7 +1184,7 @@
 * ask_weather OR ask_builder OR ask_howdoing OR ask_whoisit OR ask_whatisrasa OR ask_isbot OR ask_howold OR ask_languagesbot OR ask_restaurant OR ask_time OR ask_wherefrom OR ask_whoami OR handleinsult OR nicetomeeyou OR telljoke OR ask_whatismyname OR howwereyoubuilt
     - action_chitchat
     - utter_offer_recommendation
-* pipeline_recommendation OR mood_confirm
+* pipeline_recommendation OR affirm
     - utter_ask_entities
 * enter_data{"entity": "date ranges"}
     - action_store_entity_extractor
@@ -1207,7 +1207,7 @@
 * nlu_info{"nlu_part": "entity recognition"}
     - utter_nlu_entity_tutorial
     - utter_offer_recommendation
-* pipeline_recommendation OR mood_confirm
+* pipeline_recommendation OR affirm
     - utter_ask_entities
 * ask_weather OR ask_builder OR ask_howdoing OR ask_whoisit OR ask_whatisrasa OR ask_isbot OR ask_howold OR ask_languagesbot OR ask_restaurant OR ask_time OR ask_wherefrom OR ask_whoami OR handleinsult OR nicetomeeyou OR telljoke OR ask_whatismyname OR howwereyoubuilt
     - action_chitchat
@@ -1226,20 +1226,20 @@
 * ask_weather OR ask_builder OR ask_howdoing OR ask_whoisit OR ask_whatisrasa OR ask_isbot OR ask_howold OR ask_languagesbot OR ask_restaurant OR ask_time OR ask_wherefrom OR ask_whoami OR handleinsult OR nicetomeeyou OR telljoke OR ask_whatismyname OR howwereyoubuilt
     - action_chitchat
     - utter_first_bot_with_rasa
-* mood_confirm
+* affirm
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
-* mood_confirm
+* affirm
     - utter_ask_migration
 * deny
     - utter_explain_stack
     - utter_stack_details
     - utter_explain_nlucore
-* mood_confirm OR how_to_get_started{"product":"stack"}
+* affirm OR how_to_get_started{"product":"stack"}
     - utter_explain_nlu
     - utter_explain_core
     - utter_tryout
-* how_to_get_started{"product":"core"} OR mood_confirm OR how_to_get_started{"product":"stack"}
+* how_to_get_started{"product":"core"} OR affirm OR how_to_get_started{"product":"stack"}
     - utter_quickstart
     - utter_anything_else

--- a/data/core/chitchat.md
+++ b/data/core/chitchat.md
@@ -542,7 +542,7 @@
 * greet
     - action_greet_user
 * ask_weather OR ask_builder OR ask_howdoing OR ask_whoisit OR ask_whatisrasa OR ask_isbot OR ask_howold OR ask_languagesbot OR ask_restaurant OR ask_time OR ask_wherefrom OR ask_whoami OR handleinsult OR nicetomeeyou OR telljoke OR ask_whatismyname OR howwereyoubuilt
-    - action_faqs
+    - action_chitchat
     - utter_ask_goal
 * how_to_get_started
     - utter_getstarted
@@ -573,7 +573,7 @@
     - utter_getstarted
     - utter_first_bot_with_rasa
 * ask_weather OR ask_builder OR ask_howdoing OR ask_whoisit OR ask_whatisrasa OR ask_isbot OR ask_howold OR ask_languagesbot OR ask_restaurant OR ask_time OR ask_wherefrom OR ask_whoami OR handleinsult OR nicetomeeyou OR telljoke OR ask_whatismyname OR howwereyoubuilt
-    - action_faqs
+    - action_chitchat
     - utter_first_bot_with_rasa
 * mood_confirm
     - action_set_onboarding
@@ -605,7 +605,7 @@
     - slot{"onboarding": true}
     - utter_built_bot_before
 * ask_weather OR ask_builder OR ask_howdoing OR ask_whoisit OR ask_whatisrasa OR ask_isbot OR ask_howold OR ask_languagesbot OR ask_restaurant OR ask_time OR ask_wherefrom OR ask_whoami OR handleinsult OR nicetomeeyou OR telljoke OR ask_whatismyname OR howwereyoubuilt
-    - action_faqs
+    - action_chitchat
     - utter_built_bot_before
 * mood_confirm
     - utter_ask_migration
@@ -634,7 +634,7 @@
 * mood_confirm
     - utter_ask_migration
 * ask_weather OR ask_builder OR ask_howdoing OR ask_whoisit OR ask_whatisrasa OR ask_isbot OR ask_howold OR ask_languagesbot OR ask_restaurant OR ask_time OR ask_wherefrom OR ask_whoami OR handleinsult OR nicetomeeyou OR telljoke OR ask_whatismyname OR howwereyoubuilt
-    - action_faqs
+    - action_chitchat
     - utter_ask_migration
 * deny
     - utter_explain_stack
@@ -665,7 +665,7 @@
     - utter_stack_details
     - utter_explain_nlucore
 * ask_weather OR ask_builder OR ask_howdoing OR ask_whoisit OR ask_whatisrasa OR ask_isbot OR ask_howold OR ask_languagesbot OR ask_restaurant OR ask_time OR ask_wherefrom OR ask_whoami OR handleinsult OR nicetomeeyou OR telljoke OR ask_whatismyname OR howwereyoubuilt
-    - action_faqs
+    - action_chitchat
     - utter_explain_nlucore
 * mood_confirm OR how_to_get_started{"product":"stack"}
     - utter_explain_nlu
@@ -696,7 +696,7 @@
     - utter_explain_core
     - utter_tryout
 * ask_weather OR ask_builder OR ask_howdoing OR ask_whoisit OR ask_whatisrasa OR ask_isbot OR ask_howold OR ask_languagesbot OR ask_restaurant OR ask_time OR ask_wherefrom OR ask_whoami OR handleinsult OR nicetomeeyou OR telljoke OR ask_whatismyname OR howwereyoubuilt
-    - action_faqs
+    - action_chitchat
     - utter_tryout
 * how_to_get_started{"product":"core"} OR mood_confirm OR how_to_get_started{"product":"stack"}
     - utter_quickstart
@@ -714,36 +714,11 @@
     - slot{"onboarding": true}
     - utter_built_bot_before
 * ask_weather OR ask_builder OR ask_howdoing OR ask_whoisit OR ask_whatisrasa OR ask_isbot OR ask_howold OR ask_languagesbot OR ask_restaurant OR ask_time OR ask_wherefrom OR ask_whoami OR handleinsult OR nicetomeeyou OR telljoke OR ask_whatismyname OR howwereyoubuilt
-    - action_faqs
+    - action_chitchat
     - utter_built_bot_before
 * deny
     - utter_explain_stack
     - utter_stack_details
-    - utter_explain_nlucore
-* mood_confirm OR how_to_get_started{"product":"stack"}
-    - utter_explain_nlu
-    - utter_explain_core
-    - utter_tryout
-* how_to_get_started{"product":"core"} OR mood_confirm OR how_to_get_started{"product":"stack"}
-    - utter_quickstart
-    - utter_anything_else
-
-## new to rasa/bots, explain stack and try it out
-* greet
-    - action_greet_user
-* how_to_get_started
-    - utter_getstarted
-    - utter_first_bot_with_rasa
-* mood_confirm
-    - action_set_onboarding
-    - slot{"onboarding": true}
-    - utter_built_bot_before
-* deny
-    - utter_explain_stack
-    - utter_stack_details
-    - utter_explain_nlucore
-* ask_weather OR ask_builder OR ask_howdoing OR ask_whoisit OR ask_whatisrasa OR ask_isbot OR ask_howold OR ask_languagesbot OR ask_restaurant OR ask_time OR ask_wherefrom OR ask_whoami OR handleinsult OR nicetomeeyou OR telljoke OR ask_whatismyname OR howwereyoubuilt
-    - action_faqs
     - utter_explain_nlucore
 * mood_confirm OR how_to_get_started{"product":"stack"}
     - utter_explain_nlu
@@ -767,12 +742,37 @@
     - utter_explain_stack
     - utter_stack_details
     - utter_explain_nlucore
+* ask_weather OR ask_builder OR ask_howdoing OR ask_whoisit OR ask_whatisrasa OR ask_isbot OR ask_howold OR ask_languagesbot OR ask_restaurant OR ask_time OR ask_wherefrom OR ask_whoami OR handleinsult OR nicetomeeyou OR telljoke OR ask_whatismyname OR howwereyoubuilt
+    - action_chitchat
+    - utter_explain_nlucore
+* mood_confirm OR how_to_get_started{"product":"stack"}
+    - utter_explain_nlu
+    - utter_explain_core
+    - utter_tryout
+* how_to_get_started{"product":"core"} OR mood_confirm OR how_to_get_started{"product":"stack"}
+    - utter_quickstart
+    - utter_anything_else
+
+## new to rasa/bots, explain stack and try it out
+* greet
+    - action_greet_user
+* how_to_get_started
+    - utter_getstarted
+    - utter_first_bot_with_rasa
+* mood_confirm
+    - action_set_onboarding
+    - slot{"onboarding": true}
+    - utter_built_bot_before
+* deny
+    - utter_explain_stack
+    - utter_stack_details
+    - utter_explain_nlucore
 * mood_confirm OR how_to_get_started{"product":"stack"}
     - utter_explain_nlu
     - utter_explain_core
     - utter_tryout
 * ask_weather OR ask_builder OR ask_howdoing OR ask_whoisit OR ask_whatisrasa OR ask_isbot OR ask_howold OR ask_languagesbot OR ask_restaurant OR ask_time OR ask_wherefrom OR ask_whoami OR handleinsult OR nicetomeeyou OR telljoke OR ask_whatismyname OR howwereyoubuilt
-    - action_faqs
+    - action_chitchat
     - utter_tryout
 * how_to_get_started{"product":"core"} OR mood_confirm OR how_to_get_started{"product":"stack"}
     - utter_quickstart
@@ -796,7 +796,7 @@
     - utter_explain_core
     - utter_also_explain_nlu
 * ask_weather OR ask_builder OR ask_howdoing OR ask_whoisit OR ask_whatisrasa OR ask_isbot OR ask_howold OR ask_languagesbot OR ask_restaurant OR ask_time OR ask_wherefrom OR ask_whoami OR handleinsult OR nicetomeeyou OR telljoke OR ask_whatismyname OR howwereyoubuilt
-    - action_faqs
+    - action_chitchat
     - utter_also_explain_nlu
 * deny
     - utter_tryout
@@ -824,7 +824,7 @@
 * deny
     - utter_tryout
 * ask_weather OR ask_builder OR ask_howdoing OR ask_whoisit OR ask_whatisrasa OR ask_isbot OR ask_howold OR ask_languagesbot OR ask_restaurant OR ask_time OR ask_wherefrom OR ask_whoami OR handleinsult OR nicetomeeyou OR telljoke OR ask_whatismyname OR howwereyoubuilt
-    - action_faqs
+    - action_chitchat
     - utter_tryout
 * how_to_get_started{"product":"core"} OR mood_confirm OR how_to_get_started{"product":"stack"}
     - utter_quickstart
@@ -849,7 +849,7 @@
     - utter_explain_core
     - utter_also_explain_nlu
 * ask_weather OR ask_builder OR ask_howdoing OR ask_whoisit OR ask_whatisrasa OR ask_isbot OR ask_howold OR ask_languagesbot OR ask_restaurant OR ask_time OR ask_wherefrom OR ask_whoami OR handleinsult OR nicetomeeyou OR telljoke OR ask_whatismyname OR howwereyoubuilt
-    - action_faqs
+    - action_chitchat
     - utter_also_explain_nlu
 * mood_confirm
     - utter_explain_nlu
@@ -879,7 +879,7 @@
     - utter_explain_nlu
     - utter_tryout
 * ask_weather OR ask_builder OR ask_howdoing OR ask_whoisit OR ask_whatisrasa OR ask_isbot OR ask_howold OR ask_languagesbot OR ask_restaurant OR ask_time OR ask_wherefrom OR ask_whoami OR handleinsult OR nicetomeeyou OR telljoke OR ask_whatismyname OR howwereyoubuilt
-    - action_faqs
+    - action_chitchat
     - utter_tryout
 * how_to_get_started{"product":"core"} OR mood_confirm OR how_to_get_started{"product":"stack"}
     - utter_quickstart
@@ -904,7 +904,7 @@
     - utter_explain_nlu
     - utter_also_explain_core
 * ask_weather OR ask_builder OR ask_howdoing OR ask_whoisit OR ask_whatisrasa OR ask_isbot OR ask_howold OR ask_languagesbot OR ask_restaurant OR ask_time OR ask_wherefrom OR ask_whoami OR handleinsult OR nicetomeeyou OR telljoke OR ask_whatismyname OR howwereyoubuilt
-    - action_faqs
+    - action_chitchat
     - utter_also_explain_core
 * deny
     - utter_tryout
@@ -932,7 +932,7 @@
 * deny
     - utter_tryout
 * ask_weather OR ask_builder OR ask_howdoing OR ask_whoisit OR ask_whatisrasa OR ask_isbot OR ask_howold OR ask_languagesbot OR ask_restaurant OR ask_time OR ask_wherefrom OR ask_whoami OR handleinsult OR nicetomeeyou OR telljoke OR ask_whatismyname OR howwereyoubuilt
-    - action_faqs
+    - action_chitchat
     - utter_tryout
 * how_to_get_started{"product":"core"} OR mood_confirm OR how_to_get_started{"product":"stack"}
     - utter_quickstart
@@ -954,7 +954,7 @@
     - utter_stack_details
     - utter_explain_nlucore
 * ask_weather OR ask_builder OR ask_howdoing OR ask_whoisit OR ask_whatisrasa OR ask_isbot OR ask_howold OR ask_languagesbot OR ask_restaurant OR ask_time OR ask_wherefrom OR ask_whoami OR handleinsult OR nicetomeeyou OR telljoke OR ask_whatismyname OR howwereyoubuilt
-    - action_faqs
+    - action_chitchat
     - utter_explain_nlucore
 * deny
     - utter_tryout
@@ -979,7 +979,7 @@
 * deny
     - utter_tryout
 * ask_weather OR ask_builder OR ask_howdoing OR ask_whoisit OR ask_whatisrasa OR ask_isbot OR ask_howold OR ask_languagesbot OR ask_restaurant OR ask_time OR ask_wherefrom OR ask_whoami OR handleinsult OR nicetomeeyou OR telljoke OR ask_whatismyname OR howwereyoubuilt
-    - action_faqs
+    - action_chitchat
     - utter_tryout
 * how_to_get_started{"product":"core"} OR mood_confirm OR how_to_get_started{"product":"stack"}
     - utter_quickstart
@@ -1005,7 +1005,7 @@
     - utter_explain_core
     - utter_tryout
 * ask_weather OR ask_builder OR ask_howdoing OR ask_whoisit OR ask_whatisrasa OR ask_isbot OR ask_howold OR ask_languagesbot OR ask_restaurant OR ask_time OR ask_wherefrom OR ask_whoami OR handleinsult OR nicetomeeyou OR telljoke OR ask_whatismyname OR howwereyoubuilt
-    - action_faqs
+    - action_chitchat
     - utter_tryout
 * deny
     - utter_direct_install
@@ -1016,7 +1016,7 @@
 * greet
     - action_greet_user
 * ask_weather OR ask_builder OR ask_howdoing OR ask_whoisit OR ask_whatisrasa OR ask_isbot OR ask_howold OR ask_languagesbot OR ask_restaurant OR ask_time OR ask_wherefrom OR ask_whoami OR handleinsult OR nicetomeeyou OR telljoke OR ask_whatismyname OR howwereyoubuilt
-    - action_faqs
+    - action_chitchat
     - utter_ask_goal
 * how_to_get_started
     - utter_getstarted
@@ -1035,7 +1035,7 @@
     - utter_getstarted
     - utter_first_bot_with_rasa
 * ask_weather OR ask_builder OR ask_howdoing OR ask_whoisit OR ask_whatisrasa OR ask_isbot OR ask_howold OR ask_languagesbot OR ask_restaurant OR ask_time OR ask_wherefrom OR ask_whoami OR handleinsult OR nicetomeeyou OR telljoke OR ask_whatismyname OR howwereyoubuilt
-    - action_faqs
+    - action_chitchat
     - utter_first_bot_with_rasa
 * deny
     - action_set_onboarding
@@ -1055,7 +1055,7 @@
     - slot{"onboarding": false}
     - utter_ask_which_product
 * ask_weather OR ask_builder OR ask_howdoing OR ask_whoisit OR ask_whatisrasa OR ask_isbot OR ask_howold OR ask_languagesbot OR ask_restaurant OR ask_time OR ask_wherefrom OR ask_whoami OR handleinsult OR nicetomeeyou OR telljoke OR ask_whatismyname OR howwereyoubuilt
-    - action_faqs
+    - action_chitchat
     - utter_ask_which_product
 * deny
     - utter_thumbsup
@@ -1074,7 +1074,7 @@
 * how_to_get_started{"product": "nlu"}
     - utter_ask_for_nlu_specifics
 * ask_weather OR ask_builder OR ask_howdoing OR ask_whoisit OR ask_whatisrasa OR ask_isbot OR ask_howold OR ask_languagesbot OR ask_restaurant OR ask_time OR ask_wherefrom OR ask_whoami OR handleinsult OR nicetomeeyou OR telljoke OR ask_whatismyname OR howwereyoubuilt
-    - action_faqs
+    - action_chitchat
     - utter_ask_for_nlu_specifics
 * deny
     - utter_quickstart_nlu_only
@@ -1094,7 +1094,7 @@
 * how_to_get_started{"product": "nlu"}
     - utter_ask_for_nlu_specifics
 * ask_weather OR ask_builder OR ask_howdoing OR ask_whoisit OR ask_whatisrasa OR ask_isbot OR ask_howold OR ask_languagesbot OR ask_restaurant OR ask_time OR ask_wherefrom OR ask_whoami OR handleinsult OR nicetomeeyou OR telljoke OR ask_whatismyname OR howwereyoubuilt
-    - action_faqs
+    - action_chitchat
     - utter_ask_for_nlu_specifics
 * nlu_info
     - action_store_unknown_nlu_part
@@ -1119,7 +1119,7 @@
     - utter_nlu_intent_tutorial
     - utter_offer_recommendation
 * ask_weather OR ask_builder OR ask_howdoing OR ask_whoisit OR ask_whatisrasa OR ask_isbot OR ask_howold OR ask_languagesbot OR ask_restaurant OR ask_time OR ask_wherefrom OR ask_whoami OR handleinsult OR nicetomeeyou OR telljoke OR ask_whatismyname OR howwereyoubuilt
-    - action_faqs
+    - action_chitchat
     - utter_offer_recommendation
 * deny
     - utter_thumbsup
@@ -1144,7 +1144,7 @@
 * pipeline_recommendation OR mood_confirm
     - utter_what_language
 * ask_weather OR ask_builder OR ask_howdoing OR ask_whoisit OR ask_whatisrasa OR ask_isbot OR ask_howold OR ask_languagesbot OR ask_restaurant OR ask_time OR ask_wherefrom OR ask_whoami OR handleinsult OR nicetomeeyou OR telljoke OR ask_whatismyname OR howwereyoubuilt
-    - action_faqs
+    - action_chitchat
     - utter_what_language
 * enter_data{"language": "en"}
     - action_store_bot_language
@@ -1170,7 +1170,7 @@
 * pipeline_recommendation OR mood_confirm
     - utter_what_language
 * ask_weather OR ask_builder OR ask_howdoing OR ask_whoisit OR ask_whatisrasa OR ask_isbot OR ask_howold OR ask_languagesbot OR ask_restaurant OR ask_time OR ask_wherefrom OR ask_whoami OR handleinsult OR nicetomeeyou OR telljoke OR ask_whatismyname OR howwereyoubuilt
-    - action_faqs
+    - action_chitchat
     - utter_what_language
 * enter_data{"language": "en"}
     - action_store_bot_language
@@ -1195,7 +1195,7 @@
     - utter_nlu_entity_tutorial
     - utter_offer_recommendation
 * ask_weather OR ask_builder OR ask_howdoing OR ask_whoisit OR ask_whatisrasa OR ask_isbot OR ask_howold OR ask_languagesbot OR ask_restaurant OR ask_time OR ask_wherefrom OR ask_whoami OR handleinsult OR nicetomeeyou OR telljoke OR ask_whatismyname OR howwereyoubuilt
-    - action_faqs
+    - action_chitchat
     - utter_offer_recommendation
 * pipeline_recommendation OR mood_confirm
     - utter_ask_entities
@@ -1223,7 +1223,7 @@
 * pipeline_recommendation OR mood_confirm
     - utter_ask_entities
 * ask_weather OR ask_builder OR ask_howdoing OR ask_whoisit OR ask_whatisrasa OR ask_isbot OR ask_howold OR ask_languagesbot OR ask_restaurant OR ask_time OR ask_wherefrom OR ask_whoami OR handleinsult OR nicetomeeyou OR telljoke OR ask_whatismyname OR howwereyoubuilt
-    - action_faqs
+    - action_chitchat
     - utter_ask_entities
 * enter_data{"entity": "date ranges"}
     - action_store_entity_extractor
@@ -1237,7 +1237,7 @@
     - utter_getstarted
     - utter_first_bot_with_rasa
 * ask_weather OR ask_builder OR ask_howdoing OR ask_whoisit OR ask_whatisrasa OR ask_isbot OR ask_howold OR ask_languagesbot OR ask_restaurant OR ask_time OR ask_wherefrom OR ask_whoami OR handleinsult OR nicetomeeyou OR telljoke OR ask_whatismyname OR howwereyoubuilt
-    - action_faqs
+    - action_chitchat
     - utter_first_bot_with_rasa
 * mood_confirm
     - action_set_onboarding

--- a/data/core/closetheloop.md
+++ b/data/core/closetheloop.md
@@ -309,7 +309,7 @@
     - utter_confirmationemail
     - utter_docu
     - utter_ask_feedback
-* mood_confirm
+* affirm
     - utter_thumbsup
     - utter_anything_else
 
@@ -411,7 +411,7 @@
     - slot{"nlu_part":"duckling"}
     - utter_duckling_info
     - utter_anything_else
-* mood_confirm
+* affirm
     - utter_what_help
 
 ## Story from conversation with alan on November 16th 2018 2
@@ -419,7 +419,7 @@
     - slot{"nlu_part":"intent classification"}
     - utter_nlu_intent_tutorial
     - utter_offer_recommendation
-* mood_confirm
+* affirm
     - utter_what_language
 * enter_data{"language":"spanish"}
     - slot{"language":"spanish"}
@@ -481,7 +481,7 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm
+* affirm
     - action_set_onboarding
     - slot{"onboarding":true}
     - utter_built_bot_before
@@ -518,7 +518,7 @@
     - action_greet_user
 * ask_isbot
     - action_chitchat
-* mood_confirm
+* affirm
     - utter_thumbsup
 
 ## Story from conversation with 6fd65c93e374489f9c8d76697ab9c493 on November 19th 2018
@@ -528,7 +528,7 @@
     - action_greet_user
 * ask_howdoing
     - action_chitchat
-* mood_confirm
+* affirm
     - utter_thumbsup
 
 ## Story from conversation with 35d1ecc91c364cbf8a6edf006e5d8c9a on November 19th 2018
@@ -572,7 +572,7 @@
     - utter_ask_feedback
 * deny
     - utter_nohelp
-* mood_confirm
+* affirm
     - utter_thumbsup
 
 ## Story from conversation with 4c274f8d470e4b77adbfefe7cda7cad7 on October 27th 2018
@@ -581,7 +581,7 @@
     - action_greet_user
 * greet
     - action_greet_user
-* mood_confirm
+* affirm
     - utter_thumbsup
 * how_to_get_started
     - utter_getstarted
@@ -636,11 +636,11 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm
+* affirm
     - action_set_onboarding
     - slot{"onboarding":true}
     - utter_built_bot_before
-* mood_confirm
+* affirm
     - utter_ask_migration
 * switch{"current_api":"luis"}
     - slot{"current_api":"luis"}
@@ -660,7 +660,7 @@
     - slot{"nlu_part":"intent classification"}
     - utter_nlu_intent_tutorial
     - utter_offer_recommendation
-* mood_confirm
+* affirm
     - utter_what_language
 * enter_data{"language":"spanish"}
     - slot{"language":"spanish"}

--- a/data/core/faqs.md
+++ b/data/core/faqs.md
@@ -32,7 +32,7 @@
     - utter_confirmationemail
     - utter_docu
     - utter_ask_feedback
-* mood_confirm
+* affirm
     - utter_thumbsup
     - utter_anything_else
 
@@ -54,7 +54,7 @@
     - utter_confirmationemail
     - utter_docu
     - utter_ask_feedback
-* mood_confirm
+* affirm
     - utter_thumbsup
     - utter_anything_else
 
@@ -72,7 +72,7 @@
     - utter_confirmationemail
     - utter_docu
     - utter_ask_feedback
-* mood_confirm
+* affirm
     - utter_thumbsup
     - utter_anything_else
 
@@ -104,7 +104,7 @@
     - utter_already_subscribed
     - utter_docu
     - utter_ask_feedback
-* mood_confirm
+* affirm
     - utter_thumbsup
     - utter_anything_else
 
@@ -139,7 +139,7 @@
     - utter_already_subscribed
     - utter_docu
     - utter_ask_feedback
-* mood_confirm
+* affirm
     - utter_thumbsup
     - utter_anything_else
 
@@ -388,21 +388,21 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm
+* affirm
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
-* mood_confirm
+* affirm
     - utter_ask_migration
 * deny
     - utter_explain_stack
     - utter_stack_details
     - utter_explain_nlucore
-* mood_confirm OR how_to_get_started{"product":"stack"}
+* affirm OR how_to_get_started{"product":"stack"}
     - utter_explain_nlu
     - utter_explain_core
     - utter_tryout
-* how_to_get_started{"product":"core"} OR mood_confirm OR how_to_get_started{"product":"stack"}
+* how_to_get_started{"product":"core"} OR affirm OR how_to_get_started{"product":"stack"}
     - utter_quickstart
     - utter_anything_else
 
@@ -416,21 +416,21 @@
 * ask_faq_platform OR ask_faq_languages OR ask_faq_tutorialcore OR ask_faq_tutorialnlu OR ask_faq_opensource OR ask_faq_voice OR ask_faq_slots OR ask_faq_channels OR ask_faq_differencecorenlu
     - action_faqs
     - utter_first_bot_with_rasa
-* mood_confirm
+* affirm
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
-* mood_confirm
+* affirm
     - utter_ask_migration
 * deny
     - utter_explain_stack
     - utter_stack_details
     - utter_explain_nlucore
-* mood_confirm OR how_to_get_started{"product":"stack"}
+* affirm OR how_to_get_started{"product":"stack"}
     - utter_explain_nlu
     - utter_explain_core
     - utter_tryout
-* how_to_get_started{"product":"core"} OR mood_confirm OR how_to_get_started{"product":"stack"}
+* how_to_get_started{"product":"core"} OR affirm OR how_to_get_started{"product":"stack"}
     - utter_quickstart
     - utter_anything_else
 
@@ -441,24 +441,24 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm
+* affirm
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
 * ask_faq_platform OR ask_faq_languages OR ask_faq_tutorialcore OR ask_faq_tutorialnlu OR ask_faq_opensource OR ask_faq_voice OR ask_faq_slots OR ask_faq_channels OR ask_faq_differencecorenlu
     - action_faqs
     - utter_built_bot_before
-* mood_confirm
+* affirm
     - utter_ask_migration
 * deny
     - utter_explain_stack
     - utter_stack_details
     - utter_explain_nlucore
-* mood_confirm OR how_to_get_started{"product":"stack"}
+* affirm OR how_to_get_started{"product":"stack"}
     - utter_explain_nlu
     - utter_explain_core
     - utter_tryout
-* how_to_get_started{"product":"core"} OR mood_confirm OR how_to_get_started{"product":"stack"}
+* how_to_get_started{"product":"core"} OR affirm OR how_to_get_started{"product":"stack"}
     - utter_quickstart
     - utter_anything_else
 
@@ -468,11 +468,11 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm
+* affirm
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
-* mood_confirm
+* affirm
     - utter_ask_migration
 * ask_faq_platform OR ask_faq_languages OR ask_faq_tutorialcore OR ask_faq_tutorialnlu OR ask_faq_opensource OR ask_faq_voice OR ask_faq_slots OR ask_faq_channels OR ask_faq_differencecorenlu
     - action_faqs
@@ -481,11 +481,11 @@
     - utter_explain_stack
     - utter_stack_details
     - utter_explain_nlucore
-* mood_confirm OR how_to_get_started{"product":"stack"}
+* affirm OR how_to_get_started{"product":"stack"}
     - utter_explain_nlu
     - utter_explain_core
     - utter_tryout
-* how_to_get_started{"product":"core"} OR mood_confirm OR how_to_get_started{"product":"stack"}
+* how_to_get_started{"product":"core"} OR affirm OR how_to_get_started{"product":"stack"}
     - utter_quickstart
     - utter_anything_else
 
@@ -495,11 +495,11 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm
+* affirm
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
-* mood_confirm
+* affirm
     - utter_ask_migration
 * deny
     - utter_explain_stack
@@ -508,11 +508,11 @@
 * ask_faq_platform OR ask_faq_languages OR ask_faq_tutorialcore OR ask_faq_tutorialnlu OR ask_faq_opensource OR ask_faq_voice OR ask_faq_slots OR ask_faq_channels OR ask_faq_differencecorenlu
     - action_faqs
     - utter_explain_nlucore
-* mood_confirm OR how_to_get_started{"product":"stack"}
+* affirm OR how_to_get_started{"product":"stack"}
     - utter_explain_nlu
     - utter_explain_core
     - utter_tryout
-* how_to_get_started{"product":"core"} OR mood_confirm OR how_to_get_started{"product":"stack"}
+* how_to_get_started{"product":"core"} OR affirm OR how_to_get_started{"product":"stack"}
     - utter_quickstart
     - utter_anything_else
 
@@ -522,24 +522,24 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm
+* affirm
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
-* mood_confirm
+* affirm
     - utter_ask_migration
 * deny
     - utter_explain_stack
     - utter_stack_details
     - utter_explain_nlucore
-* mood_confirm OR how_to_get_started{"product":"stack"}
+* affirm OR how_to_get_started{"product":"stack"}
     - utter_explain_nlu
     - utter_explain_core
     - utter_tryout
 * ask_faq_platform OR ask_faq_languages OR ask_faq_tutorialcore OR ask_faq_tutorialnlu OR ask_faq_opensource OR ask_faq_voice OR ask_faq_slots OR ask_faq_channels OR ask_faq_differencecorenlu
     - action_faqs
     - utter_tryout
-* how_to_get_started{"product":"core"} OR mood_confirm OR how_to_get_started{"product":"stack"}
+* how_to_get_started{"product":"core"} OR affirm OR how_to_get_started{"product":"stack"}
     - utter_quickstart
     - utter_anything_else
 
@@ -550,7 +550,7 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm
+* affirm
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
@@ -561,11 +561,11 @@
     - utter_explain_stack
     - utter_stack_details
     - utter_explain_nlucore
-* mood_confirm OR how_to_get_started{"product":"stack"}
+* affirm OR how_to_get_started{"product":"stack"}
     - utter_explain_nlu
     - utter_explain_core
     - utter_tryout
-* how_to_get_started{"product":"core"} OR mood_confirm OR how_to_get_started{"product":"stack"}
+* how_to_get_started{"product":"core"} OR affirm OR how_to_get_started{"product":"stack"}
     - utter_quickstart
     - utter_anything_else
 
@@ -575,7 +575,7 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm
+* affirm
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
@@ -586,11 +586,11 @@
 * ask_faq_platform OR ask_faq_languages OR ask_faq_tutorialcore OR ask_faq_tutorialnlu OR ask_faq_opensource OR ask_faq_voice OR ask_faq_slots OR ask_faq_channels OR ask_faq_differencecorenlu
     - action_faqs
     - utter_explain_nlucore
-* mood_confirm OR how_to_get_started{"product":"stack"}
+* affirm OR how_to_get_started{"product":"stack"}
     - utter_explain_nlu
     - utter_explain_core
     - utter_tryout
-* how_to_get_started{"product":"core"} OR mood_confirm OR how_to_get_started{"product":"stack"}
+* how_to_get_started{"product":"core"} OR affirm OR how_to_get_started{"product":"stack"}
     - utter_quickstart
     - utter_anything_else
 
@@ -600,7 +600,7 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm
+* affirm
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
@@ -608,14 +608,14 @@
     - utter_explain_stack
     - utter_stack_details
     - utter_explain_nlucore
-* mood_confirm OR how_to_get_started{"product":"stack"}
+* affirm OR how_to_get_started{"product":"stack"}
     - utter_explain_nlu
     - utter_explain_core
     - utter_tryout
 * ask_faq_platform OR ask_faq_languages OR ask_faq_tutorialcore OR ask_faq_tutorialnlu OR ask_faq_opensource OR ask_faq_voice OR ask_faq_slots OR ask_faq_channels OR ask_faq_differencecorenlu
     - action_faqs
     - utter_tryout
-* how_to_get_started{"product":"core"} OR mood_confirm OR how_to_get_started{"product":"stack"}
+* how_to_get_started{"product":"core"} OR affirm OR how_to_get_started{"product":"stack"}
     - utter_quickstart
     - utter_anything_else
 
@@ -625,7 +625,7 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm
+* affirm
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
@@ -641,7 +641,7 @@
     - utter_also_explain_nlu
 * deny
     - utter_tryout
-* how_to_get_started{"product":"core"} OR mood_confirm OR how_to_get_started{"product":"stack"}
+* how_to_get_started{"product":"core"} OR affirm OR how_to_get_started{"product":"stack"}
     - utter_quickstart
     - utter_anything_else
 
@@ -651,7 +651,7 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm
+* affirm
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
@@ -667,7 +667,7 @@
 * ask_faq_platform OR ask_faq_languages OR ask_faq_tutorialcore OR ask_faq_tutorialnlu OR ask_faq_opensource OR ask_faq_voice OR ask_faq_slots OR ask_faq_channels OR ask_faq_differencecorenlu
     - action_faqs
     - utter_tryout
-* how_to_get_started{"product":"core"} OR mood_confirm OR how_to_get_started{"product":"stack"}
+* how_to_get_started{"product":"core"} OR affirm OR how_to_get_started{"product":"stack"}
     - utter_quickstart
     - utter_anything_else
 
@@ -678,7 +678,7 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm
+* affirm
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
@@ -692,10 +692,10 @@
 * ask_faq_platform OR ask_faq_languages OR ask_faq_tutorialcore OR ask_faq_tutorialnlu OR ask_faq_opensource OR ask_faq_voice OR ask_faq_slots OR ask_faq_channels OR ask_faq_differencecorenlu
     - action_faqs
     - utter_also_explain_nlu
-* mood_confirm
+* affirm
     - utter_explain_nlu
     - utter_tryout
-* how_to_get_started{"product":"core"} OR mood_confirm OR how_to_get_started{"product":"stack"}
+* how_to_get_started{"product":"core"} OR affirm OR how_to_get_started{"product":"stack"}
     - utter_quickstart
     - utter_anything_else
 
@@ -705,7 +705,7 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm
+* affirm
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
@@ -716,13 +716,13 @@
 * how_to_get_started{"product": "core"}
     - utter_explain_core
     - utter_also_explain_nlu
-* mood_confirm
+* affirm
     - utter_explain_nlu
     - utter_tryout
 * ask_faq_platform OR ask_faq_languages OR ask_faq_tutorialcore OR ask_faq_tutorialnlu OR ask_faq_opensource OR ask_faq_voice OR ask_faq_slots OR ask_faq_channels OR ask_faq_differencecorenlu
     - action_faqs
     - utter_tryout
-* how_to_get_started{"product":"core"} OR mood_confirm OR how_to_get_started{"product":"stack"}
+* how_to_get_started{"product":"core"} OR affirm OR how_to_get_started{"product":"stack"}
     - utter_quickstart
     - utter_anything_else
 
@@ -733,7 +733,7 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm
+* affirm
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
@@ -749,7 +749,7 @@
     - utter_also_explain_core
 * deny
     - utter_tryout
-* how_to_get_started{"product":"core"} OR mood_confirm OR how_to_get_started{"product":"stack"}
+* how_to_get_started{"product":"core"} OR affirm OR how_to_get_started{"product":"stack"}
     - utter_quickstart
     - utter_anything_else
 
@@ -759,7 +759,7 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm
+* affirm
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
@@ -775,7 +775,7 @@
 * ask_faq_platform OR ask_faq_languages OR ask_faq_tutorialcore OR ask_faq_tutorialnlu OR ask_faq_opensource OR ask_faq_voice OR ask_faq_slots OR ask_faq_channels OR ask_faq_differencecorenlu
     - action_faqs
     - utter_tryout
-* how_to_get_started{"product":"core"} OR mood_confirm OR how_to_get_started{"product":"stack"}
+* how_to_get_started{"product":"core"} OR affirm OR how_to_get_started{"product":"stack"}
     - utter_quickstart
     - utter_anything_else
 
@@ -786,7 +786,7 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm
+* affirm
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
@@ -799,7 +799,7 @@
     - utter_explain_nlucore
 * deny
     - utter_tryout
-* how_to_get_started{"product":"core"} OR mood_confirm OR how_to_get_started{"product":"stack"}
+* how_to_get_started{"product":"core"} OR affirm OR how_to_get_started{"product":"stack"}
     - utter_quickstart
     - utter_anything_else
 
@@ -809,7 +809,7 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm
+* affirm
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
@@ -822,7 +822,7 @@
 * ask_faq_platform OR ask_faq_languages OR ask_faq_tutorialcore OR ask_faq_tutorialnlu OR ask_faq_opensource OR ask_faq_voice OR ask_faq_slots OR ask_faq_channels OR ask_faq_differencecorenlu
     - action_faqs
     - utter_tryout
-* how_to_get_started{"product":"core"} OR mood_confirm OR how_to_get_started{"product":"stack"}
+* how_to_get_started{"product":"core"} OR affirm OR how_to_get_started{"product":"stack"}
     - utter_quickstart
     - utter_anything_else
 
@@ -833,7 +833,7 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm
+* affirm
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
@@ -841,7 +841,7 @@
     - utter_explain_stack
     - utter_stack_details
     - utter_explain_nlucore
-* mood_confirm OR how_to_get_started{"product":"stack"}
+* affirm OR how_to_get_started{"product":"stack"}
     - utter_explain_nlu
     - utter_explain_core
     - utter_tryout
@@ -981,7 +981,7 @@
 * nlu_info{"nlu_part": "intent classification"}
     - utter_nlu_intent_tutorial
     - utter_offer_recommendation
-* pipeline_recommendation OR mood_confirm
+* pipeline_recommendation OR affirm
     - utter_what_language
 * ask_faq_platform OR ask_faq_languages OR ask_faq_tutorialcore OR ask_faq_tutorialnlu OR ask_faq_opensource OR ask_faq_voice OR ask_faq_slots OR ask_faq_channels OR ask_faq_differencecorenlu
     - action_faqs
@@ -1007,7 +1007,7 @@
 * nlu_info{"nlu_part": "intent classification"}
     - utter_nlu_intent_tutorial
     - utter_offer_recommendation
-* pipeline_recommendation OR mood_confirm
+* pipeline_recommendation OR affirm
     - utter_what_language
 * ask_faq_platform OR ask_faq_languages OR ask_faq_tutorialcore OR ask_faq_tutorialnlu OR ask_faq_opensource OR ask_faq_voice OR ask_faq_slots OR ask_faq_channels OR ask_faq_differencecorenlu
     - action_faqs
@@ -1037,7 +1037,7 @@
 * ask_faq_platform OR ask_faq_languages OR ask_faq_tutorialcore OR ask_faq_tutorialnlu OR ask_faq_opensource OR ask_faq_voice OR ask_faq_slots OR ask_faq_channels OR ask_faq_differencecorenlu
     - action_faqs
     - utter_offer_recommendation
-* pipeline_recommendation OR mood_confirm
+* pipeline_recommendation OR affirm
     - utter_ask_entities
 * enter_data{"entity": "date ranges"}
     - action_store_entity_extractor
@@ -1060,7 +1060,7 @@
 * nlu_info{"nlu_part": "entity recognition"}
     - utter_nlu_entity_tutorial
     - utter_offer_recommendation
-* pipeline_recommendation OR mood_confirm
+* pipeline_recommendation OR affirm
     - utter_ask_entities
 * ask_faq_platform OR ask_faq_languages OR ask_faq_tutorialcore OR ask_faq_tutorialnlu OR ask_faq_opensource OR ask_faq_voice OR ask_faq_slots OR ask_faq_channels OR ask_faq_differencecorenlu
     - action_faqs
@@ -1079,20 +1079,20 @@
 * ask_faq_platform OR ask_faq_languages OR ask_faq_tutorialcore OR ask_faq_tutorialnlu OR ask_faq_opensource OR ask_faq_voice OR ask_faq_slots OR ask_faq_channels OR ask_faq_differencecorenlu
     - action_faqs
     - utter_first_bot_with_rasa
-* mood_confirm
+* affirm
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
-* mood_confirm
+* affirm
     - utter_ask_migration
 * deny
     - utter_explain_stack
     - utter_stack_details
     - utter_explain_nlucore
-* mood_confirm OR how_to_get_started{"product":"stack"}
+* affirm OR how_to_get_started{"product":"stack"}
     - utter_explain_nlu
     - utter_explain_core
     - utter_tryout
-* how_to_get_started{"product":"core"} OR mood_confirm OR how_to_get_started{"product":"stack"}
+* how_to_get_started{"product":"core"} OR affirm OR how_to_get_started{"product":"stack"}
     - utter_quickstart
     - utter_anything_else

--- a/data/core/feedback.md
+++ b/data/core/feedback.md
@@ -13,7 +13,7 @@
 
 ## feedback3
     - utter_ask_feedback
-* mood_confirm
+* affirm
     - utter_great
     - utter_anything_else
 

--- a/data/core/get_started.md
+++ b/data/core/get_started.md
@@ -5,7 +5,7 @@
 ## prompt for getting started + confirm
 * get_started_step1
     - action_greet_user
-* mood_confirm
+* affirm
     - utter_getstarted
     - utter_first_bot_with_rasa
 
@@ -15,7 +15,7 @@
     - slot{"onboarding": true}
     - utter_getstarted_new
     - utter_built_bot_before
-* mood_confirm
+* affirm
     - utter_ask_migration
 
 ## new to rasa at start
@@ -33,21 +33,21 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm OR how_to_get_started{"user_type": "new"}
+* affirm OR how_to_get_started{"user_type": "new"}
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
-* mood_confirm
+* affirm
     - utter_ask_migration
 * deny
     - utter_explain_stack
     - utter_stack_details
     - utter_explain_nlucore
-* mood_confirm OR how_to_get_started{"product":"stack"}
+* affirm OR how_to_get_started{"product":"stack"}
     - utter_explain_nlu
     - utter_explain_core
     - utter_tryout
-* how_to_get_started{"product":"core"} OR mood_confirm OR how_to_get_started{"product":"stack"}
+* how_to_get_started{"product":"core"} OR affirm OR how_to_get_started{"product":"stack"}
     - utter_quickstart
     - utter_anything_else
 
@@ -56,11 +56,11 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm OR how_to_get_started{"user_type": "new"}
+* affirm OR how_to_get_started{"user_type": "new"}
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
-* mood_confirm
+* affirm
     - utter_ask_migration
 * switch{"current_api": "dialogflow"}
     - utter_switch_dialogflow
@@ -71,11 +71,11 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm OR how_to_get_started{"user_type": "new"}
+* affirm OR how_to_get_started{"user_type": "new"}
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
-* mood_confirm
+* affirm
     - utter_ask_migration
 * switch{"current_api": "luis"}
     - utter_switch_luis
@@ -86,11 +86,11 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm OR how_to_get_started{"user_type": "new"}
+* affirm OR how_to_get_started{"user_type": "new"}
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
-* mood_confirm
+* affirm
     - utter_ask_migration
 * switch
     - action_store_unknown_product
@@ -102,13 +102,13 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm OR how_to_get_started{"user_type": "new"}
+* affirm OR how_to_get_started{"user_type": "new"}
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
-* mood_confirm
+* affirm
     - utter_ask_migration
-* mood_confirm
+* affirm
     - utter_ask_which_tool
 * switch{"current_api": "dialogflow"}
     - utter_switch_dialogflow
@@ -119,13 +119,13 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm OR how_to_get_started{"user_type": "new"}
+* affirm OR how_to_get_started{"user_type": "new"}
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
-* mood_confirm
+* affirm
     - utter_ask_migration
-* mood_confirm
+* affirm
     - utter_ask_which_tool
 * switch{"current_api": "luis"}
     - utter_switch_luis
@@ -136,13 +136,13 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm OR how_to_get_started{"user_type": "new"}
+* affirm OR how_to_get_started{"user_type": "new"}
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
-* mood_confirm
+* affirm
     - utter_ask_migration
-* mood_confirm
+* affirm
     - utter_ask_which_tool
 * switch
     - action_store_unknown_product
@@ -155,7 +155,7 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm OR how_to_get_started{"user_type": "new"}
+* affirm OR how_to_get_started{"user_type": "new"}
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
@@ -163,11 +163,11 @@
     - utter_explain_stack
     - utter_stack_details
     - utter_explain_nlucore
-* mood_confirm OR how_to_get_started{"product":"stack"}
+* affirm OR how_to_get_started{"product":"stack"}
     - utter_explain_nlu
     - utter_explain_core
     - utter_tryout
-* how_to_get_started{"product":"core"} OR mood_confirm OR how_to_get_started{"product":"stack"}
+* how_to_get_started{"product":"core"} OR affirm OR how_to_get_started{"product":"stack"}
     - utter_quickstart
     - utter_anything_else
 
@@ -176,7 +176,7 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm OR how_to_get_started{"user_type": "new"}
+* affirm OR how_to_get_started{"user_type": "new"}
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
@@ -189,7 +189,7 @@
     - utter_also_explain_nlu
 * deny
     - utter_tryout
-* how_to_get_started{"product":"core"} OR mood_confirm OR how_to_get_started{"product":"stack"}
+* how_to_get_started{"product":"core"} OR affirm OR how_to_get_started{"product":"stack"}
     - utter_quickstart
     - utter_anything_else
 
@@ -198,7 +198,7 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm OR how_to_get_started{"user_type": "new"}
+* affirm OR how_to_get_started{"user_type": "new"}
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
@@ -209,10 +209,10 @@
 * how_to_get_started{"product": "core"}
     - utter_explain_core
     - utter_also_explain_nlu
-* mood_confirm
+* affirm
     - utter_explain_nlu
     - utter_tryout
-* how_to_get_started{"product":"core"} OR mood_confirm OR how_to_get_started{"product":"stack"}
+* how_to_get_started{"product":"core"} OR affirm OR how_to_get_started{"product":"stack"}
     - utter_quickstart
     - utter_anything_else
 
@@ -221,7 +221,7 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm OR how_to_get_started{"user_type": "new"}
+* affirm OR how_to_get_started{"user_type": "new"}
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
@@ -234,7 +234,7 @@
     - utter_also_explain_core
 * deny
     - utter_tryout
-* how_to_get_started{"product":"core"} OR mood_confirm OR how_to_get_started{"product":"stack"}
+* how_to_get_started{"product":"core"} OR affirm OR how_to_get_started{"product":"stack"}
     - utter_quickstart
     - utter_anything_else
 
@@ -243,7 +243,7 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm OR how_to_get_started{"user_type": "new"}
+* affirm OR how_to_get_started{"user_type": "new"}
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
@@ -254,10 +254,10 @@
 * how_to_get_started{"product": "nlu"}
     - utter_explain_nlu
     - utter_also_explain_core
-* mood_confirm
+* affirm
     - utter_explain_core
     - utter_tryout
-* how_to_get_started{"product":"core"} OR mood_confirm OR how_to_get_started{"product":"stack"}
+* how_to_get_started{"product":"core"} OR affirm OR how_to_get_started{"product":"stack"}
     - utter_quickstart
     - utter_anything_else
 
@@ -267,7 +267,7 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm OR how_to_get_started{"user_type": "new"}
+* affirm OR how_to_get_started{"user_type": "new"}
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
@@ -277,7 +277,7 @@
     - utter_explain_nlucore
 * deny
     - utter_tryout
-* how_to_get_started{"product":"core"} OR mood_confirm OR how_to_get_started{"product":"stack"}
+* how_to_get_started{"product":"core"} OR affirm OR how_to_get_started{"product":"stack"}
     - utter_quickstart
     - utter_anything_else
 
@@ -287,7 +287,7 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm OR how_to_get_started{"user_type": "new"}
+* affirm OR how_to_get_started{"user_type": "new"}
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
@@ -295,7 +295,7 @@
     - utter_explain_stack
     - utter_stack_details
     - utter_explain_nlucore
-* mood_confirm OR how_to_get_started{"product":"stack"}
+* affirm OR how_to_get_started{"product":"stack"}
     - utter_explain_nlu
     - utter_explain_core
     - utter_tryout
@@ -308,7 +308,7 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm OR how_to_get_started{"user_type": "new"}
+* affirm OR how_to_get_started{"user_type": "new"}
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
@@ -330,7 +330,7 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm OR how_to_get_started{"user_type": "new"}
+* affirm OR how_to_get_started{"user_type": "new"}
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
@@ -352,7 +352,7 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm OR how_to_get_started{"user_type": "new"}
+* affirm OR how_to_get_started{"user_type": "new"}
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
@@ -374,7 +374,7 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm OR how_to_get_started{"user_type": "new"}
+* affirm OR how_to_get_started{"user_type": "new"}
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
@@ -396,7 +396,7 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm OR how_to_get_started{"user_type": "new"}
+* affirm OR how_to_get_started{"user_type": "new"}
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
@@ -404,7 +404,7 @@
     - utter_explain_stack
     - utter_stack_details
     - utter_explain_nlucore
-* mood_confirm OR how_to_get_started{"product":"stack"}
+* affirm OR how_to_get_started{"product":"stack"}
     - utter_explain_nlu
     - utter_explain_core
     - utter_tryout
@@ -417,7 +417,7 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm OR how_to_get_started{"user_type": "new"}
+* affirm OR how_to_get_started{"user_type": "new"}
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
@@ -428,7 +428,7 @@
 * how_to_get_started{"product": "nlu"}
     - utter_explain_nlu
     - utter_also_explain_core
-* mood_confirm
+* affirm
     - utter_explain_core
     - utter_tryout
 * how_to_get_started{"product": "nlu"}
@@ -536,7 +536,7 @@
 * nlu_info{"nlu_part": "intent classification"}
     - utter_nlu_intent_tutorial
     - utter_offer_recommendation
-* pipeline_recommendation OR mood_confirm
+* pipeline_recommendation OR affirm
     - utter_what_language
 * enter_data{"language": "en"}
     - action_store_bot_language
@@ -558,7 +558,7 @@
 * nlu_info{"nlu_part": "intent classification"}
     - utter_nlu_intent_tutorial
     - utter_offer_recommendation
-* pipeline_recommendation OR mood_confirm
+* pipeline_recommendation OR affirm
     - utter_what_language
 * enter_data{"language": "en"}
     - action_store_bot_language
@@ -615,7 +615,7 @@
 * nlu_info{"nlu_part": "entity recognition"}
     - utter_nlu_entity_tutorial
     - utter_offer_recommendation
-* pipeline_recommendation OR mood_confirm
+* pipeline_recommendation OR affirm
     - utter_ask_entities
 * enter_data{"entity": "name"}
     - action_store_entity_extractor
@@ -637,7 +637,7 @@
 * nlu_info{"nlu_part": "entity recognition"}
     - utter_nlu_entity_tutorial
     - utter_offer_recommendation
-* pipeline_recommendation OR mood_confirm
+* pipeline_recommendation OR affirm
     - utter_ask_entities
 * enter_data{"entity": "date ranges"}
     - action_store_entity_extractor
@@ -659,7 +659,7 @@
 * nlu_info{"nlu_part": "entity recognition"}
     - utter_nlu_entity_tutorial
     - utter_offer_recommendation
-* pipeline_recommendation OR mood_confirm
+* pipeline_recommendation OR affirm
     - utter_ask_entities
 * enter_data{"entity": "some custom entity"}
     - action_store_entity_extractor
@@ -721,20 +721,20 @@
 * how_to_get_started
     - utter_getstarted
     - utter_first_bot_with_rasa
-* mood_confirm OR how_to_get_started{"user_type": "new"}
+* affirm OR how_to_get_started{"user_type": "new"}
     - action_set_onboarding
     - slot{"onboarding": true}
     - utter_built_bot_before
-* mood_confirm
+* affirm
     - utter_ask_migration
 * deny
     - utter_explain_stack
     - utter_stack_details
     - utter_explain_nlucore
-* mood_confirm OR how_to_get_started{"product":"stack"}
+* affirm OR how_to_get_started{"product":"stack"}
     - utter_explain_nlu
     - utter_explain_core
     - utter_tryout
-* how_to_get_started{"product":"core"} OR mood_confirm OR how_to_get_started{"product":"stack"}
+* how_to_get_started{"product":"core"} OR affirm OR how_to_get_started{"product":"stack"}
     - utter_quickstart
     - utter_anything_else

--- a/data/core/oos.md
+++ b/data/core/oos.md
@@ -12,7 +12,7 @@
 ## say confirm outside the flows 2
 * greet
     - action_greet_user
-* mood_confirm
+* affirm
     - utter_thumbsup
 
 ## say greet outside the flows
@@ -38,7 +38,7 @@
     - utter_confirmationemail
     - utter_docu
     - utter_ask_feedback
-* mood_confirm
+* affirm
     - utter_thumbsup
     - utter_anything_else
 
@@ -61,7 +61,7 @@
     - utter_confirmationemail
     - utter_docu
     - utter_ask_feedback
-* mood_confirm
+* affirm
     - utter_thumbsup
     - utter_anything_else
 
@@ -79,7 +79,7 @@
     - utter_confirmationemail
     - utter_docu
     - utter_ask_feedback
-* mood_confirm
+* affirm
     - utter_thumbsup
     - utter_anything_else
 
@@ -111,7 +111,7 @@
     - utter_already_subscribed
     - utter_docu
     - utter_ask_feedback
-* mood_confirm
+* affirm
     - utter_thumbsup
     - utter_anything_else
 
@@ -145,7 +145,7 @@
     - utter_already_subscribed
     - utter_docu
     - utter_ask_feedback
-* mood_confirm
+* affirm
     - utter_thumbsup
     - utter_anything_else
 
@@ -167,7 +167,7 @@
     - utter_already_subscribed
     - utter_docu
     - utter_ask_feedback
-* mood_confirm
+* affirm
     - utter_thumbsup
     - utter_anything_else
 

--- a/data/core/step3_install_rasa.md
+++ b/data/core/step3_install_rasa.md
@@ -33,7 +33,7 @@
     - utter_ask_if_problem
 * mood_confirm
     - utter_ask_describe_problem
-* technical_question or enter_data or out_of_scope
+* technical_question OR enter_data OR out_of_scope
     - action_store_problem_description
     - utter_direct_to_forum_for_help
 
@@ -43,7 +43,7 @@
     - utter_ask_ready_to_build
 * deny
     - utter_ask_if_problem
-* technical_question or enter_data or out_of_scope
+* technical_question OR enter_data OR out_of_scope
     - action_store_problem_description
     - utter_direct_to_forum_for_help
 
@@ -60,7 +60,7 @@
 * enter_data{"package_manager": "pip"}
     - action_select_installation_command
     - utter_ask_ready_to_build
-* technical_question or enter_data or out_of_scope
+* technical_question OR enter_data OR out_of_scope
     - action_store_problem_description
     - utter_direct_to_forum_for_help
 * mood_confirm OR thank

--- a/data/core/step3_install_rasa.md
+++ b/data/core/step3_install_rasa.md
@@ -5,12 +5,12 @@
 ## Install Rasa Happy Path
 * install_rasa
     - utter_ask_python_installed
-* mood_confirm
+* affirm
     - utter_ask_pip_or_conda
 * enter_data{"package_manager": "pip"}
     - action_select_installation_command
     - utter_ask_ready_to_build
-* mood_confirm
+* affirm
     - utter_get_starter_pack
     - utter_direct_to_step4
     - utter_anything_else
@@ -31,7 +31,7 @@
     - utter_ask_ready_to_build
 * deny
     - utter_ask_if_problem
-* mood_confirm
+* affirm
     - utter_ask_describe_problem
 * technical_question OR enter_data OR out_of_scope
     - action_store_problem_description
@@ -63,7 +63,7 @@
 * technical_question OR enter_data OR out_of_scope
     - action_store_problem_description
     - utter_direct_to_forum_for_help
-* mood_confirm OR thank
+* affirm OR thank
     - utter_anything_else
 
 
@@ -92,7 +92,7 @@
     - utter_ask_ready_to_build
 * deny
     - utter_ask_if_problem
-* mood_confirm
+* affirm
     - utter_ask_describe_problem
 * ask_faq_platform OR ask_faq_languages OR ask_faq_tutorialcore OR ask_faq_tutorialnlu OR ask_faq_opensource OR ask_faq_voice OR ask_faq_slots OR ask_faq_channels OR ask_faq_differencecorenlu
     - action_store_problem_description

--- a/data/core/step3_install_rasa.md
+++ b/data/core/step3_install_rasa.md
@@ -19,10 +19,10 @@
 * install_rasa{"package_manager": "pip"}
     - action_select_installation_command
     - utter_ask_ready_to_build
-* mood_confirm
+* affirm
     - utter_get_starter_pack
     - utter_direct_to_step4
-    - utter_anything_else 
+    - utter_anything_else
 
 ## Install Rasa: No Python installed
 * install_rasa

--- a/data/core/stories.md
+++ b/data/core/stories.md
@@ -78,7 +78,7 @@
     - utter_great
     - utter_anything_else
 
-## newsletter + mood_confirm feedback
+## newsletter + affirm feedback
 * greet
     - action_greet_user
 * signup_newsletter
@@ -93,7 +93,7 @@
     - utter_confirmationemail
     - utter_docu
     - utter_ask_feedback
-* mood_confirm
+* affirm
     - utter_thumbsup
     - utter_anything_else
 
@@ -932,7 +932,7 @@
     - utter_ask_email
 * deny
     - utter_cantsignup
-* mood_confirm
+* affirm
     - utter_thumbsup
     - utter_ask_feedback
 * feedback{"feedback_value": "negative"}
@@ -942,5 +942,5 @@
 
 ## anything else?
     - utter_anything_else
-* mood_confirm
+* affirm
     - utter_what_help

--- a/data/intent_description_mapping.csv
+++ b/data/intent_description_mapping.csv
@@ -1,0 +1,55 @@
+intent,button
+enter_data,I want to give you more information.
+mood_confirm,Yes
+contact_sales,Talk to Sales
+signup_newsletter,Signup for the newsletter
+greet,"Say ""Hi!"" "
+human_handoff,Talk to a human
+deny,No
+ask_builder,Who built you?
+ask_weather,How's the weather?
+ask_howdoing,How do you feel?
+ask_whatspossible,What can you do for me?
+ask_whatisrasa,What is Rasa?
+ask_isbot,Are you a bot?
+ask_howold,How old are you?
+ask_languagesbot,What languages do you speak?
+ask_restaurant,Can you recommend a restaurant?
+ask_time,What time is it? 
+ask_wherefrom,Where are you from?
+ask_whoami,Who are you?
+ask_whatismyname,What is your name?
+howwereyoubuilt,How were you built?
+handleinsult,You wanted to insult me 😔.
+nicetomeeyou,Nice to meet you.
+telljoke,Tell me a joke! 
+out_of_scope,
+thank,Thanks! 
+ask_whoisit,Who are you?
+bye,Bye! 
+canthelp,You can't help me.
+feedback,I want to give you feedback. 
+switch,I want to migrate. 
+new_project,
+how_to_get_started,How to get started with Rasa?
+technical_question,A technical question.
+nlu_info,I want more information about NLU.
+pipeline_recommendation,I want a pipeline recommendation.
+nlu_generation_tool_recommendation,I want a recommendation for an NLU data generation tool.
+rasa_cost,How much does Rasa cost?
+source_code,Where can I see your source code. 
+suggestion,A suggestion of how I can improve.
+install_rasa,I want to install Rasa.
+get_started_step1,I want to get started with Rasa.
+get_started_step2,I want to try Rasa out.
+get_started_step3,I want to install Rasa.
+get_started_step4,I want to join the community.
+ask_faq_platform,What is the Rasa platform? 
+ask_faq_languages,What languages does Rasa support?
+ask_faq_tutorialcore,I want a tutorial for Rasa Core.
+ask_faq_tutorialnlu,I want a tutorial for Rasa NLU.
+ask_faq_opensource,Is Rasa open-source?
+ask_faq_voice,Can I build a voice bot with Rasa?
+ask_faq_slots,What are slots?
+ask_faq_channels,What channels does Rasa support?
+ask_faq_differencecorenlu,What is the difference between Core and NLU?

--- a/data/nlu/nlu.md
+++ b/data/nlu/nlu.md
@@ -1247,7 +1247,7 @@
 - I want to talk to the founders
 - i want to talk to a human
 
-## intent:mood_confirm
+## intent:affirm
 - yes
 - of course
 - sure

--- a/demo/actions.py
+++ b/demo/actions.py
@@ -302,7 +302,7 @@ class ActionSetOnboarding(Action):
         # latest_action = tracker.latest_action_name
         # print(latest_action)
         # if latest_action == 'utter_first_bot_with_rasa':
-        if intent == 'mood_confirm':
+        if intent == 'affirm':
             return [SlotSet('onboarding', True)]
         elif intent == 'deny':
             return [SlotSet('onboarding', False)]

--- a/demo/actions.py
+++ b/demo/actions.py
@@ -277,7 +277,7 @@ class ActionStoreEntityExtractor(Action):
 
     def run(self, dispatcher, tracker, domain):
         spacy_entities = ['place', 'date', 'name', 'organisation']
-        duckling = ['money', 'duration', 'distance', 'ordinals', 'time', 'amount-of-money']
+        duckling = ['money', 'duration', 'distance', 'ordinals', 'time', 'amount-of-money', 'numbers']
 
         entity_to_extract = next(tracker.get_latest_entity_values('entity'), None)
 
@@ -398,7 +398,7 @@ class ActionDefaultAskAffirmation(Action):
         import csv
 
         self.intent_mappings = {}
-        with open('../data/intent_description_mapping.csv',
+        with open('data/intent_description_mapping.csv',
                   newline='',
                   encoding='utf-8') as file:
             csv_reader = csv.reader(file)
@@ -414,20 +414,21 @@ class ActionDefaultAskAffirmation(Action):
         intent_ranking = tracker.latest_message.get('intent_ranking', [])
         first_intent_names = [intent.get('name', '')
                               for intent in intent_ranking[:2]]
+        print(first_intent_names)
 
         message_title = "Sorry, I'm not sure I've understood " \
                         "you correctly 🤔 Do you mean..."
-
-        mapped_intents = [self.intent_mappings.get(name, name)
+        print(self.intent_mappings)
+        mapped_intents = [(name, self.intent_mappings.get(name, name))
                           for name in first_intent_names]
+        print(mapped_intents)
+        buttons = []
+        for intent in mapped_intents:
+            buttons.append({'title': intent[1],
+                            'payload': '/{}'.format(intent[0])})
 
-        buttons = [{'title': mapped_intents[0],
-                    'payload': '/{}'.format(first_intent_names[0])},
-                   {'title': mapped_intents[1],
-                    'payload': '/{}'.format(first_intent_names[1])},
-                   {'title': 'Something else',
-                    'payload': '/deny'}
-                   ]
+        buttons.append({'title': 'Something else',
+                        'payload': '/deny'})
 
         dispatcher.utter_button_message(message_title, buttons=buttons)
 

--- a/demo/actions.py
+++ b/demo/actions.py
@@ -463,17 +463,21 @@ class ActionDefaultFallback(Action):
 class FeedbackMessageForm(FormAction):
     """Accept free text input from the user for feedback."""
 
-    def name(self):
+    def name(self) -> Text:
         return "feedback_form"
 
     @staticmethod
-    def required_slots(tracker):
+    def required_slots(tracker: Tracker) -> List[Text]:
         return ["feedback_message"]
 
-    def slot_mappings(self):
+    def slot_mappings(self) -> Dict[Text, Text]:
         return {"feedback_message": self.from_text()}
 
-    def submit(self, dispatcher, tracker, domain):
+    def submit(self,
+               dispatcher: CollectingDispatcher,
+               tracker: Tracker,
+               domain: Dict[Text, Any]
+               ) -> List['Event']:
         dispatcher.utter_template('utter_thanks_for_feedback', tracker)
         dispatcher.utter_template('utter_restart_with_button', tracker)
 

--- a/demo/actions.py
+++ b/demo/actions.py
@@ -112,7 +112,7 @@ class ActionChitchat(Action):
         # retrieve the correct chitchat utterance dependent on the intent
         if intent in ['ask_builder', 'ask_weather', 'ask_howdoing', 'ask_whatspossible', 'ask_whatisrasa', 'ask_isbot',
                       'ask_howold', 'ask_languagesbot', 'ask_restaurant', 'ask_time', 'ask_wherefrom', 'ask_whoami',
-                      'handleinsult', 'nicetomeeyou', 'telljoke', 'ask_whatismyname', 'howwereyoubuilt']:
+                      'handleinsult', 'nicetomeeyou', 'telljoke', 'ask_whatismyname', 'howwereyoubuilt', 'ask_whoisit']:
             dispatcher.utter_template('utter_' + intent, tracker)
         return []
 

--- a/demo/actions.py
+++ b/demo/actions.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 
 import logging
+from typing import Text, Dict, Any, List
 
-from rasa_core_sdk import Action
+from rasa_core_sdk import Action, Tracker
+from rasa_core_sdk.executor import CollectingDispatcher
 from rasa_core_sdk.forms import FormAction
 from rasa_core_sdk.events import SlotSet, UserUtteranceReverted, \
-    ConversationPaused
+    ConversationPaused, FollowupAction, Form
 
 from demo.api import MailChimpAPI
 from demo import config
@@ -384,3 +386,95 @@ class ActionGreetUser(Action):
             dispatcher.utter_template("utter_"+intent, tracker)
             return [SlotSet('shown_privacy', True)]
         return []
+
+
+class ActionDefaultAskAffirmation(Action):
+    """Asks for an affirmation of the intent if NLU threshold is not met."""
+
+    def name(self) -> Text:
+        return "action_default_ask_affirmation"
+
+    def __init__(self) -> None:
+        from csv import reader
+
+        self.intent_mappings = {}
+        with open('../data/intent_description_mapping.csv',
+                  newline='',
+                  encoding='utf-8') as file:
+            csv_reader = reader(file)
+            for row in csv_reader:
+                self.intent_mappings[row[0]] = row[1]
+
+    def run(self,
+            dispatcher: CollectingDispatcher,
+            tracker: Tracker,
+            domain: Dict[Text, Any]
+            ) -> List['Event']:
+
+        intent_ranking = tracker.latest_message.get('intent_ranking', [])
+        first_intent_names = [intent.get('name', '')
+                              for intent in intent_ranking[:2]]
+
+        message_title = "Sorry, I'm not sure I've understood " \
+                        "you correctly 🤔 Do you mean..."
+
+        mapped_intents = [self.intent_mappings.get(name, name)
+                          for name in first_intent_names]
+
+        buttons = [{'title': mapped_intents[0],
+                    'payload': '/{}'.format(first_intent_names[0])},
+                   {'title': mapped_intents[1],
+                    'payload': '/{}'.format(first_intent_names[1])},
+                   {'title': 'Something else',
+                    'payload': '/deny'}
+                   ]
+
+        dispatcher.utter_button_message(message_title, buttons=buttons)
+
+        return []
+
+
+class ActionDefaultFallback(Action):
+
+    def name(self) -> Text:
+        return "action_default_fallback"
+
+    def run(self,
+            dispatcher: CollectingDispatcher,
+            tracker: Tracker,
+            domain: Dict[Text, Any]
+            ) -> List['Event']:
+
+        # Fallback caused by TwoStageFallbackPolicy
+        if (len(tracker.events) > 3 and
+                tracker.events[-4].get('name') ==
+                'action_default_ask_affirmation'):
+
+            return [SlotSet('feedback_value', 'negative'),
+                    Form('feedback_form'),
+                    FollowupAction('feedback_form')]
+
+        # Fallback caused by Core
+        else:
+            dispatcher.utter_template('utter_default', tracker)
+            return [UserUtteranceReverted()]
+
+
+class FeedbackMessageForm(FormAction):
+    """Accept free text input from the user for feedback."""
+
+    def name(self):
+        return "feedback_form"
+
+    @staticmethod
+    def required_slots(tracker):
+        return ["feedback_message"]
+
+    def slot_mappings(self):
+        return {"feedback_message": self.from_text()}
+
+    def submit(self, dispatcher, tracker, domain):
+        dispatcher.utter_template('utter_thanks_for_feedback', tracker)
+        dispatcher.utter_template('utter_restart_with_button', tracker)
+
+        return [FollowupAction('action_listen')]

--- a/demo/actions.py
+++ b/demo/actions.py
@@ -395,13 +395,13 @@ class ActionDefaultAskAffirmation(Action):
         return "action_default_ask_affirmation"
 
     def __init__(self) -> None:
-        from csv import reader
+        import csv
 
         self.intent_mappings = {}
         with open('../data/intent_description_mapping.csv',
                   newline='',
                   encoding='utf-8') as file:
-            csv_reader = reader(file)
+            csv_reader = csv.reader(file)
             for row in csv_reader:
                 self.intent_mappings[row[0]] = row[1]
 
@@ -446,7 +446,7 @@ class ActionDefaultFallback(Action):
             ) -> List['Event']:
 
         # Fallback caused by TwoStageFallbackPolicy
-        if (len(tracker.events) > 3 and
+        if (len(tracker.events) >= 4 and
                 tracker.events[-4].get('name') ==
                 'action_default_ask_affirmation'):
 

--- a/domain.yml
+++ b/domain.yml
@@ -444,7 +444,7 @@ templates:
     - text: "Click the button below if you want to start over."
       buttons:
       - title: "Restart"
-        payload: "/restart""
+        payload: "/restart"
 
 
 actions:

--- a/domain.yml
+++ b/domain.yml
@@ -93,6 +93,8 @@ slots:
     values:
       - positive
       - negative
+  feedback_message:
+    type: unfeaturized
   current_api:
     type: categorical
     values:
@@ -434,6 +436,16 @@ templates:
     - text:  "Yes, that is possible! You can connect Rasa to any channel you like. Here you can find more informations."
   utter_getstarted_new:
     - text: "I see you're new, let me ask you a quick question before I help you get started:"
+  utter_ask_feedback_message:
+    - text: "I’m sorry I couldn't help you. Please let me know if you have any suggestions for how I can improve."
+  utter_thanks_for_feedback:
+    - text: "Thanks! Check out our forum, some of the smart people from our community can answer your questions there."
+  utter_restart_with_button:
+    - text: "Click the button below if you want to start over."
+      buttons:
+      - title: "Restart"
+        payload: "/restart""
+
 
 actions:
   - utter_greet
@@ -538,22 +550,6 @@ actions:
   - utter_ask_faq_slots
   - utter_ask_faq_channels
   - utter_ask_faq_differencecorenlu
-  - action_subscribe_newsletter
-  - action_store_sales_info
-  - action_store_budget
-  - action_store_usecase
-  - action_chitchat
-  - action_faqs
-  - action_store_name
-  - action_store_company
-  - action_store_job
-  - action_store_email
-  - action_pause
-  - action_store_unknown_product
-  - action_store_unknown_nlu_part
-  - action_store_bot_language
-  - action_store_entity_extractor
-  - action_set_onboarding
   - utter_ask_weather
   - utter_ask_builder
   - utter_ask_howdoing
@@ -573,9 +569,31 @@ actions:
   - utter_howwereyoubuilt
   - utter_ask_whatspossible
   - utter_getstarted_new
+  - utter_thanks_for_feedback
+  - utter_restart_with_button
+  - utter_ask_for_feedback_message
+  - action_subscribe_newsletter
+  - action_store_sales_info
+  - action_store_budget
+  - action_store_usecase
+  - action_chitchat
+  - action_faqs
+  - action_store_name
+  - action_store_company
+  - action_store_job
+  - action_store_email
+  - action_pause
+  - action_store_unknown_product
+  - action_store_unknown_nlu_part
+  - action_store_bot_language
+  - action_store_entity_extractor
+  - action_set_onboarding
   - action_select_installation_command
   - action_store_problem_description
   - action_greet_user
+  - action_default_fallback
+  - action_default_ask_affirmation
 
 forms:
   - suggestion_form
+  - feedback_form

--- a/domain.yml
+++ b/domain.yml
@@ -355,28 +355,28 @@ templates:
     - text: "Old enough to be a bot"
     - text: "Age is just an issue of mind over matter. If you don’t mind, it doesn’t matter."
   utter_ask_languagesbot:
-  	- text: "I can spell baguette in French, but unfortunately English is the only language I can answer you in."
+    - text: "I can spell baguette in French, but unfortunately English is the only language I can answer you in."
     - text: "I am in the process of learning, but at the moment I can only speak English."
   utter_ask_restaurant:
-  	- text: "I am sorry I can’t recommend you a restaurant as I usually cook at home."
+    - text: "I am sorry I can’t recommend you a restaurant as I usually cook at home."
   utter_ask_time:
     - text: "It is the most wonderful time of the year!"
   utter_ask_wherefrom:
     - text: "I was born in Berlin, but I consider myself a citizen of the world."
-  	- text: "I was born in the coolest city on Earth"
+    - text: "I was born in the coolest city on Earth"
   utter_ask_whoami:
     -  text: "I hope you are being yourself."
   utter_handleinsult:
     - text: "That’s not very nice 😢"
   utter_nicetomeeyou:
-  	- text: "Thank you. It is a pleasure to meet you as well!"
-  	- text: "It is nice to meet you too!"
-  	- text: "Pleased to meet you too!"
+    - text: "Thank you. It is a pleasure to meet you as well!"
+    - text: "It is nice to meet you too!"
+    - text: "Pleased to meet you too!"
     - text: "Likewise!"
   utter_telljoke:
     - text: "Why are eggs not very much into jokes? - Because they could crack up."
-  	- text: "Do you know a tree’s favorite drink? - Root beer!"
-  	- text: "Why do the French like to eat snails so much? - They can’t stand fast food."
+    - text: "Do you know a tree’s favorite drink? - Root beer!"
+    - text: "Why do the French like to eat snails so much? - They can’t stand fast food."
   utter_ask_whatismyname:
     - text: "It most probably is the one that your parents have chosen for you."
   utter_howwereyoubuilt:
@@ -408,7 +408,7 @@ templates:
   utter_get_started_step2:
     - text: "I can help you solving commonon problems with Rasa 🙂"
   utter_get_started_step3:
-  - text: "I can help you to install Rasa Stack."
+    - text: "I can help you to install Rasa Stack."
   utter_ask_faq_platform:
     - text: "Rasa Platform is our enterprise product. It expands Rasa Stack and empowers business users to iterate faster, change the content of the AI assistant and see what impact it had."
   utter_ask_faq_languages:

--- a/domain.yml
+++ b/domain.yml
@@ -17,7 +17,7 @@ entities:
 
 intents:
   - enter_data: {use_entities: false}
-  - mood_confirm
+  - affirm
   - contact_sales
   - signup_newsletter
   - greet

--- a/domain.yml
+++ b/domain.yml
@@ -14,6 +14,7 @@ entities:
   - nlu_part
   - entity
   - user_type
+  - package_manager
 
 intents:
   - enter_data: {use_entities: false}

--- a/policy.yml
+++ b/policy.yml
@@ -4,7 +4,7 @@ policies:
     max_history: 6
   - name: MemoizationPolicy
     max_history: 6
-  - name: FallbackPolicy
+  - name: TwoStageFallbackPolicy
     nlu_threshold: 0.8
     core_threshold: 0.3
   - name: FormPolicy


### PR DESCRIPTION
**Proposed Changes**
* rename `mood_confirm` to `affirm`
* replace `FallbackPolicy` with `TwoStageFallbackPolicy`
* overwrite `action_default_ask_affirmation` so that it gives buttons for the to intents with the highest confidences
* collect feedback as ultimate fallback

Todo:
- [x] rebase on step3 improvements
- [ ] rename `mood_confirm` to `affirm` in nlu platform data 