### PR TITLE
Use parentheses around the boolean expressions

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -6,7 +6,7 @@ pipeline:
   OOV_token: oov
   token_pattern: (?u)\b\w+\b
 - name: CountVectorsFeaturizer
-  analyzer: "char_wb"
+  analyzer: char_wb
   min_ngram: 1
   max_ngram: 4
 - name: EmbeddingIntentClassifier
@@ -19,12 +19,13 @@ pipeline:
   - number
   - amount-of-money
 - name: EntitySynonymMapper
-
 policies:
 - name: EmbeddingPolicy
   max_history: 10
   epochs: 20
-  batch_size: [32,64]
+  batch_size:
+  - 32
+  - 64
 - max_history: 6
   name: AugmentedMemoizationPolicy
 - core_threshold: 0.3

--- a/demo/actions.py
+++ b/demo/actions.py
@@ -492,8 +492,8 @@ class ActionDefaultAskAffirmation(Action):
 
     def get_button_title(self, intent: Text, entities: Dict[Text, Text]) -> Text:
         default_utterance_query = self.intent_mappings.intent == intent
-        utterance_query = (
-            self.intent_mappings.entities == entities.keys() & default_utterance_query
+        utterance_query = (self.intent_mappings.entities == entities.keys()) & (
+            default_utterance_query
         )
 
         utterances = self.intent_mappings[utterance_query].button.tolist()
@@ -586,7 +586,8 @@ class CommunityEventAction(Action):
         locations = "\n".join(event_items)
         dispatcher.utter_message(
             "Here are the next Rasa events:\n\n"
-            + locations + "\n\nWe hope to see you at them!"
+            + locations
+            + "\n\nWe hope to see you at them!"
         )
 
     def _utter_next_event(


### PR DESCRIPTION
Issue #351 

The parentheses are mandatory since & has a higher operator precedence than ==.
