### PR TITLE
Remove 'privacy policy' from 'out_of_scope'

### DIFF
--- a/data/nlu/nlu.md
+++ b/data/nlu/nlu.md
@@ -4143,7 +4143,6 @@
 - please hjave lunchj
 - please hurry, i have deadline in two weeks to deliver the bot it is for very big company
 - please play music
-- privacy policy
 - que puedes hacer?
 - rasa topics
 - really? you're so touchy?


### PR DESCRIPTION
Having the sentence `privacy policy` in the `out_of_scope` intent prevented the model from learning `technical_question` intents for sentences that contained the word `policy`.

The fix is to simply remove this sentence `privacy policy` from the `out_of_scope` intent. 

As you can see in the tables below, the predictions are now correct.

It is OK to remove this sentence from the `out_of_scope` intent because we always show the privacy policy at the start of every conversation. 


### These were wrong before, now are correct
sentence | prediction before change | prediction after change
-|-|-
"what is fallback policy in rasa" | out_of_scope : 0.85 | technical_question: 0.89|
"what are the policy available" | out_of_scope : 0.85 | technical_question: 0.88|
"what is the policy" | out_of_scope : 0.93 | technical_question: 0.89|

### These were correct before, are still correct
sentence | prediction before change | prediction after change
-|-|-
"what are fallback policies in rasa" | technical_question : 0.94 | technical_question: 0.89|
"best policies to be used"| technical_question : 0.95 | technical_question: 0.90|
