### PR TITLE
Correct parsing of events from HTML

### DIFF
--- a/data/nlu/nlu.md
+++ b/data/nlu/nlu.md
@@ -1764,57 +1764,6 @@
 - what you doing?
 - what you talk about?
 
-## intent:ask_when_next_event
-- Assuming that there is an upcoming event, when is that event?
-- At what time is the next event scheduled?
-- At which date the next community event will take place?
-- By chance do you know the date of next community event?
-- Do you know the exact date for the next community event?
-- Do you know when is the next event in [Montreal](location)?
-- If there is an upcoming event when is it?
-- Is next community event held in 2019?
-- Is there a Rasa event in [San Francisco](location)
-- Is there an event in [Montreal](location)?
-- Is there any special in next community event?
-- On what day is the next event scheduled?
-- Tell me when the next community event is happening;
-- What and when is the next event?
-- What even is coming up next and when is it please?
-- What is the date of the next community event?
-- What's the next community event
-- What's the next rasa event
-- When does the upcoming event occur?
-- When is it planned the next event in [Montreal](location)?
-- When is it scheduled the next community event?
-- When is it that the next event occurs?
-- When is the next community event?
-- When is the next event in [Berlin](location)
-- When is the next event scheduled?
-- When is the next user group meetup
-- When will the next event occur in the community?
-- Where is next community event held?
-- do you have an event in [Berlin](location)
-- is there an event in [Montreal](location)
-- what community events are there?
-- what date is the next community event?
-- when is our next group event going to take place?
-- when is the event within the community gonna happen?
-- when is the next community event gonna be?
-- when is the next event?
-- when is the next group event going to be?
-- when will our next group event be?
-- when will the community event take place?
-- when will the next community event be?
-- will there be an event in my city?
-- When is the next event in [Detroit](location)?
-- What is the next event in [Paris](location)?
-- When is the next event in [detroit](location)?
-- What is the next event in [paris](location)?
-- When is the next event for [Detroit](location)?
-- What is the next event for [Paris](location)?
-- When is the next event for [detroit](location)?
-- What is the next event for [paris](location)?
-
 ## intent:ask_wherefrom
 - Are you from around here?
 - Around where are you from?
@@ -1915,15 +1864,64 @@
 - What are the events in [Detroit](location)?
 - When are the events in [Paris](location)?
 - what are the events in [Berlin](location)?
-- What are the events in [detroit](location)?
+- What are the events in [Switzerland](location)?
 - When are the events in [paris](location)?
 - what are the events in [berlin](location)?
 - What are the events for [Detroit](location)?
 - When are the events for [Paris](location)?
-- what are the events for [Berlin](location)?
-- What are the events for [detroit](location)?
+- what are the events for [China](location)?
+- What are the events for [New York](location)?
 - When are the events for [paris](location)?
 - what are the events for [berlin](location)?
+- Assuming that there is an upcoming event, when is that event?
+- At what time is the next event scheduled?
+- At which date the next community event will take place?
+- By chance do you know the date of next community event?
+- Do you know the exact date for the next community event?
+- Do you know when is the next event in [Montreal](location)?
+- If there is an upcoming event when is it?
+- Is next community event held in 2019?
+- Is there a Rasa event in [San Francisco](location)
+- Is there an event in [Montreal](location)?
+- Is there any special in next community event?
+- On what day is the next event scheduled?
+- Tell me when the next community event is happening;
+- What and when is the next event?
+- What even is coming up next and when is it please?
+- What is the date of the next community event?
+- What's the next community event
+- What's the next rasa event
+- When does the upcoming event occur?
+- When is it planned the next event in [Montreal](location)?
+- When is it scheduled the next community event?
+- When is it that the next event occurs?
+- When is the next community event?
+- When is the next event in [Berlin](location)
+- When is the next event scheduled?
+- When is the next user group meetup
+- When will the next event occur in the community?
+- Where is next community event held?
+- do you have an event in [Berlin](location)
+- is there an event in [Montreal](location)
+- what community events are there?
+- what date is the next community event?
+- when is our next group event going to take place?
+- when is the event within the community gonna happen?
+- when is the next community event gonna be?
+- when is the next event?
+- when is the next group event going to be?
+- when will our next group event be?
+- when will the community event take place?
+- when will the next community event be?
+- will there be an event in my city?
+- When is the next event in [california](location)?
+- What is the next event in [Paris](location)?
+- When is the next event in [detroit](location)?
+- What is the next event in [san francisco](location)?
+- When is the next event for [Detroit](location)?
+- What is the next event for [Seattle](location)?
+- When is the next event for [India](location)?
+- What is the next event for [paris](location)?
 
 ## intent:ask_whoami
 - Can you tell me who I am?
@@ -4862,6 +4860,12 @@
 - thnks
 - thx
 - yes thanks
+
+## lookup: location
+data/nlu/lookups/location.txt
+
+## lookup: product
+data/nlu/lookups/products.txt
 
 ## synonym: duration
 - how long

--- a/data/nlu/nlu.md
+++ b/data/nlu/nlu.md
@@ -1805,6 +1805,15 @@
 - when will our next group event be?
 - when will the community event take place?
 - when will the next community event be?
+- will there be an event in my city?
+- When is the next event in [Detroit](location)?
+- What is the next event in [Paris](location)?
+- When is the next event in [detroit](location)?
+- What is the next event in [paris](location)?
+- When is the next event for [Detroit](location)?
+- What is the next event for [Paris](location)?
+- When is the next event for [detroit](location)?
+- What is the next event for [paris](location)?
 
 ## intent:ask_wherefrom
 - Are you from around here?
@@ -1903,7 +1912,18 @@
 - what kind of events will be held?
 - what sort of social events are we throwing?
 - where can I see a calendar of community events?
-- will there be an event in my city?
+- What are the events in [Detroit](location)?
+- When are the events in [Paris](location)?
+- what are the events in [Berlin](location)?
+- What are the events in [detroit](location)?
+- When are the events in [paris](location)?
+- what are the events in [berlin](location)?
+- What are the events for [Detroit](location)?
+- When are the events for [Paris](location)?
+- what are the events for [Berlin](location)?
+- What are the events for [detroit](location)?
+- When are the events for [paris](location)?
+- what are the events for [berlin](location)?
 
 ## intent:ask_whoami
 - Can you tell me who I am?

--- a/demo/actions.py
+++ b/demo/actions.py
@@ -583,6 +583,7 @@ class CommunityEventAction(Action):
         events = self._get_events()
         events_for_location = None
         if location:
+            location = location.title()
             events_for_location = [
                 e
                 for e in events
@@ -603,8 +604,8 @@ class CommunityEventAction(Action):
 
         return []
 
+    @staticmethod
     def _utter_event_overview(
-        self,
         tracker: Tracker,
         dispatcher: CollectingDispatcher,
         events: List,
@@ -633,8 +634,8 @@ class CommunityEventAction(Action):
             f"{header} \n\n {locations} \n\n We hope to see you at them!"
         )
 
+    @staticmethod
     def _utter_next_event(
-        self,
         tracker: Tracker,
         dispatcher: CollectingDispatcher,
         events: List,

--- a/demo/actions.py
+++ b/demo/actions.py
@@ -591,9 +591,13 @@ class CommunityEventAction(Action):
             ]
 
         if not events:
-            dispatcher.utter_message(text="Looks like we don't have currently have any Rasa events planned.")
+            dispatcher.utter_message(
+                text="Looks like we don't have currently have any Rasa events planned."
+            )
         else:
-            self._utter_events(tracker, dispatcher, events, events_for_location, location)
+            self._utter_events(
+                tracker, dispatcher, events, events_for_location, location
+            )
 
         return []
 

--- a/demo/community_events.py
+++ b/demo/community_events.py
@@ -81,12 +81,10 @@ def get_community_events() -> List[CommunityEvent]:
 
         events = soup.find("ul", attrs={"id": "events-list"}).find_all("li")
         # [1].find("ul").find_all("li")
-        print(events)
         events = [CommunityEvent.from_html(e) for e in events]
 
         now = datetime.date.today()
         events = [e for e in events if e is not None and e.date >= now]
-        print(events)
         return sorted(events, key=lambda e: e.date)
 
     return []

--- a/demo/community_events.py
+++ b/demo/community_events.py
@@ -5,7 +5,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-DATE_FORMAT = "%d %B %Y"
+DATE_FORMAT = "%d %B, %Y"
 
 
 class CommunityEvent:
@@ -24,18 +24,16 @@ class CommunityEvent:
 
     @classmethod
     def from_html(cls, html) -> Optional["CommunityEvent"]:
-        link = html.a.get("href")
-
-        event_properties = html.get_text().split(",")
-
-        if len(event_properties) != 3:
-            logger.warning("Error when trying to parse event details from html.")
+        try:
+            city = html.contents[0]
+            link = html.contents[3].get("href")
+            name = html.contents[3].contents[0]
+            date_as_string = html.contents[8]
+            country = get_country_for(city)
+            date = parse_community_date(date_as_string).date()
+        except Exception as e:
+            logger.warning(f"Error when trying to parse event details from html.\n{e}")
             return None
-
-        city, name, date_as_string = html.get_text().split(",")
-        country = get_country_for(city)
-
-        date = parse_community_date(date_as_string).date()
 
         return cls(
             name.strip(),

--- a/domain.yml
+++ b/domain.yml
@@ -600,7 +600,7 @@ templates:
   - text: Hmm, I'm not sure that's a valid email, please make sure to include the
       full address 😅
   utter_no_event_for_location_but_next:
-  - text: Sorry, there are currently no events at your location. However, the next
+  - text: Sorry, there are currently no events in {location}. However, the next
       event is the {event_name} in {event_location} on {event_date}.
   utter_no_guide_for_switch:
   - text: Sorry, but we don't have a migration guide for that tool yet. You can still

--- a/domain.yml
+++ b/domain.yml
@@ -570,12 +570,6 @@ templates:
   - text: Sure, we can book a sales call! Let's get to know each other first 😉
   utter_must_accept:
   - text: We can't speak until you accept.
-  utter_next_event:
-  - text: The next event is the {event_name} in {event_location} on {event_date}.
-      Hope to see you there!
-  utter_next_event_for_location:
-  - text: The next event in {event_location} is the {event_name} on {event_date}.
-      Hope to see you there!
   utter_nicetomeeyou:
   - text: Likewise!
   - text: Thank you. It is a pleasure to meet you as well!
@@ -594,14 +588,9 @@ templates:
   utter_nlu_tools:
   - text: We recommend using Rasa X to easily create and classify NLU data from within
       a UI.
-  utter_no_community_event:
-  - text: Looks like we don't have currently have any Rasa events planned.
   utter_no_email:
   - text: Hmm, I'm not sure that's a valid email, please make sure to include the
       full address 😅
-  utter_no_event_for_location_but_next:
-  - text: Sorry, there are currently no events in {location}. However, the next
-      event is the {event_name} in {event_location} on {event_date}.
   utter_no_guide_for_switch:
   - text: Sorry, but we don't have a migration guide for that tool yet. You can still
       follow the [tutorial](https://rasa.com/docs/rasa/user-guide/rasa-tutorial/)
@@ -873,15 +862,11 @@ actions:
 - utter_link_to_forum
 - utter_moreinformation
 - utter_must_accept
-- utter_next_event
-- utter_next_event_for_location
 - utter_nicetomeeyou
 - utter_nlu_entity_tutorial
 - utter_nlu_intent_tutorial
 - utter_nlu_tools
-- utter_no_community_event
 - utter_no_email
-- utter_no_event_for_location_but_next
 - utter_no_guide_for_switch
 - utter_no_more_steps
 - utter_no_speak


### PR DESCRIPTION
Using html.get_text().split(",") no longer works now that the event date is provided in a format that contains a comma. 

Switched to extracting everything from html.contents.

closes https://github.com/RasaHQ/rasa-demo/issues/347