### PR TITLE
Fixed link to Python SDK in utter_ask_faq_is_programming_required

### DIFF
--- a/domain.yml
+++ b/domain.yml
@@ -203,12 +203,14 @@ templates:
   utter_ask_faq_languages:
   - text: You can use Rasa to build assistants in any language you want!
   utter_ask_faq_is_programming_required:
-  - text: "Rasa is written in Python, but programming is not required to develop an assistant. \n
-      To learn how to create an assistant, check out the [Rasa Masterclass](https://www.youtube.com/watch?v=rlAQWbhwqLA). \n\n
-      There is one place where programming skills come in handy, and that is when implementing
-      [custom actions](https://rasa.com/docs/rasa/core/actions/#custom-actions). \n\n
-      You can create an action server in Node.js, .NET, Java, or any other language and
-      define your actions there. For custom actions written in Python, we provide a small [Python SDK](link) to make development even easier"
+  - text: Rasa is written in Python, but programming is not required to develop an
+      assistant.  To learn how to create an assistant, check out the [Rasa Masterclass](https://www.youtube.com/watch?v=rlAQWbhwqLA).  There
+      is one place where programming skills come in handy, and that is when implementing
+      [custom actions](https://rasa.com/docs/rasa/core/actions/#custom-actions).  You
+      can create an action server in Node.js, .NET, Java, or any other language and
+      define your actions there. For custom actions written in Python, we provide
+      a small [Python SDK](https://rasa.com/docs/rasa/api/rasa-sdk/#rasa-sdk) to make
+      development even easier
   utter_ask_faq_tutorialnlu:
   - text: Rasa Masterclass episodes 2-4 focus on NLU. Check out episode 2 [here](https://www.youtube.com/watch?v=k5UeywXA28k).
   utter_ask_faq_opensource:


### PR DESCRIPTION
The link was wrong.

On the Rasa X instance, the identical sentence was repeated 4 times. I removed 3 of them, and then corrected the link.