### PR TITLE
Fix two-stage-fallback

### DIFF
--- a/domain.yml
+++ b/domain.yml
@@ -714,6 +714,8 @@ responses:
   - text: Rasa Masterclass covers how to [set up Rasa X](https://www.youtube.com/watch?v=IUYdwy8HPVc) and how
       to [improve your assistant](https://www.youtube.com/watch?v=LWzsS5Q-RoI) by sharing your assistant with
       others.
+  utter_ask_rephrase:
+  - text: Can you rephrase the question?
 actions:
 - action_chitchat
 - action_default_ask_affirmation


### PR DESCRIPTION
Two stage fallback was broken, because `utter_ask_rephrase` was not in the domain.

Here a test example that now works again:

![image](https://user-images.githubusercontent.com/16159200/74878117-ac291600-5334-11ea-81bc-be8aae87bab3.png)
