### PR TITLE
Fix onboarding flow bug with how to get started with rasa oss

### DIFF
--- a/data/core/step1_get_started.md
+++ b/data/core/step1_get_started.md
@@ -349,6 +349,18 @@
     - utter_explain_core
     - utter_anything_else
 
+## not new to rasa + rasa
+* how_to_get_started
+    - utter_getstarted
+    - utter_first_bot_with_rasa
+* deny
+    - action_set_onboarding
+    - slot{"onboarding": false}
+    - utter_ask_which_product
+* how_to_get_started{"product": "rasa"}
+    - utter_explain_core
+    - utter_explain_nlu
+
 ## skip to info on rasa x
 * how_to_get_started{"product": "x"}
     - slot{"product": "x"}
@@ -402,6 +414,24 @@
     - utter_explain_nlu
     - utter_explain_core
     - utter_direct_to_step2
+
+## new to rasa + rasa oss
+* how_to_get_started
+    - utter_getstarted
+    - utter_first_bot_with_rasa
+* affirm
+    - action_set_onboarding
+    - slot{"onboarding": true}
+    - utter_built_bot_before
+* affirm
+    - utter_ask_migration
+* deny
+    - utter_explain_rasa_components
+    - utter_rasa_components_details
+    - utter_ask_explain_nlucorex
+* how_to_get_started{"product": "rasa"}
+    - utter_explain_nlu
+    - utter_explain_core
 
 ## skip to info on core
 * how_to_get_started{"product": "core"}

--- a/data/nlu/nlu.md
+++ b/data/nlu/nlu.md
@@ -3765,6 +3765,14 @@
 - where to start?
 - yes i wanna know more about rasa [nlu](product)
 - I am trying to build a bot using rasa
+- more about [Rasa open source](product)
+- tell me about [rasa open source](product)
+- i want to know about [rasa Open source](product)
+- get started with [Rasa Open Source](product)
+- [Rasa open source](product)
+- [rasa open source](product)
+- [rasa Open source](product)
+- [Rasa Open Source](product)
 
 ## intent:human_handoff
 - Can I speak to anyone who can really help me?
@@ -5014,6 +5022,10 @@ data/nlu/lookups/products.txt
 
 ## synonym:rasa
 - Rasa
+- rasa open source
+- Rasa Open Source
+- Rasa open source
+- rasa Open Source
 
 ## synonym:stack
 - fullstack


### PR DESCRIPTION
- closes https://github.com/RasaHQ/rasa-demo/issues/481
- Add training data for "rasa open source" to the `how_to_get_started` intent
- add more stories with `how_to_get_started{"product": "rasa"}`