### PR TITLE
push action server image only on merge

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -64,9 +64,9 @@ jobs:
       uses: jitterbit/get-changed-files@v1
     - name: set_training
       if: |
-          contains(  steps.files.outputs.all, ' data/' ) 
-          || contains(  steps.files.outputs.all, ' config.yml' ) 
-          || contains(  steps.files.outputs.all, ' domain.yml' )
+          contains(  steps.files.outputs.all, 'data/' ) 
+          || contains(  steps.files.outputs.all, 'config.yml' ) 
+          || contains(  steps.files.outputs.all, 'domain.yml' )
       run: echo "::set-env name=RUN_TRAINING::true"
     - name: Set up Python 3.7
       if: env.RUN_TRAINING == 'true'
@@ -82,8 +82,8 @@ jobs:
       id: cvnlu
       if: |
           ( contains(github.event.pull_request.labels.*.name, 'nlu_testing_required') 
-          && contains(  steps.files.outputs.all, ' data/nlu/' ) )
-          || contains(  steps.files.outputs.all, ' config.yml' )
+          && contains(  steps.files.outputs.all, 'data/nlu/' ) )
+          || contains(  steps.files.outputs.all, 'config.yml' )
       run: |  
           rasa test nlu -f 3 --cross-validation
           python .github/workflows/format_results.py
@@ -102,9 +102,9 @@ jobs:
         rasa train
     - name: Test Training Stories
       if: |
-          contains(  steps.files.outputs.all, ' data/core/' ) 
-          || contains(  steps.files.outputs.all, ' config.yml' ) 
-          || contains(  steps.files.outputs.all, ' domain.yml' )
+          contains(  steps.files.outputs.all, 'data/core/' ) 
+          || contains(  steps.files.outputs.all, 'config.yml' ) 
+          || contains(  steps.files.outputs.all, 'domain.yml' )
       working-directory: ${{ github.workspace }}
       run: |
         rasa test core --stories test/test_stories.md --fail-on-prediction-errors
@@ -126,8 +126,8 @@ jobs:
       uses: jitterbit/get-changed-files@v1
     - name: set_actions
       if: |
-        contains(  steps.files.outputs.all, ' actions/' ) 
-        || contains(  steps.files.outputs.all, ' Dockerfile' )
+        contains(  steps.files.outputs.all, 'actions/' ) 
+        || contains(  steps.files.outputs.all, 'Dockerfile' )
       run: echo "::set-env name=ACTIONS_CHANGED::true"
     - name: Authenticate into Google Cloud Platform
       if: env.ACTIONS_CHANGED == 'true'
@@ -143,14 +143,8 @@ jobs:
       if: env.ACTIONS_CHANGED == 'true'
       run: |
         docker pull gcr.io/replicated-test/rasa-demo:latest || true
-    - name: Set Build ID from PR Ref
-      if: env.ACTIONS_CHANGED == 'true'
-      run: echo ::set-env name=BUILD_NUMBER::$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
     - name: Build Image
       if: env.ACTIONS_CHANGED == 'true'
       run: |
-        docker build -t gcr.io/replicated-test/rasa-demo:pr$BUILD_NUMBER -t gcr.io/replicated-test/rasa-demo:latest --cache-from gcr.io/replicated-test/rasa-demo:latest .
-    - name: Push PR Image to Google Cloud Container Registry
-      if: env.ACTIONS_CHANGED == 'true'
-      run: |
-        docker push gcr.io/replicated-test/rasa-demo:pr$BUILD_NUMBER
+        docker build --cache-from gcr.io/replicated-test/rasa-demo:latest .
+

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout git repository 🕝
         uses: actions/checkout@v2
 
-        - name: Authenticate into Google Cloud Platform
+      - name: Authenticate into Google Cloud Platform
         uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
         with:
           version: '275.0.0'

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -21,21 +21,21 @@ jobs:
           version: '275.0.0'
           service_account_key: ${{ secrets.GCLOUD_AUTH }}
 
-        - name: Configure Docker to use Google Cloud Platform
-          run: |
-            gcloud auth configure-docker
+      - name: Configure Docker to use Google Cloud Platform
+        run: |
+          gcloud auth configure-docker
 
-        - name: Pull Latest Image
-          run: |
-            docker pull gcr.io/replicated-test/rasa-demo:latest || true
+      - name: Pull Latest Image
+        run: |
+          docker pull gcr.io/replicated-test/rasa-demo:latest || true
 
-        - name: Set Build ID from run ID and number
-          run: echo ::set-env name=BUILD_NUMBER::$GITHUB_RUN_NUMBER-$GITHUB_RUN_ID
+      - name: Set Build ID from run ID and number
+        run: echo ::set-env name=BUILD_NUMBER::$GITHUB_RUN_NUMBER-$GITHUB_RUN_ID
 
-        - name: Build Image
-          run: |
-            docker build -t gcr.io/replicated-test/rasa-demo:run$BUILD_NUMBER -t gcr.io/replicated-test/rasa-demo:latest --cache-from gcr.io/replicated-test/rasa-demo:latest .
-        
-        - name: Push PR Image to Google Cloud Container Registry
-          run: |
-            docker push gcr.io/replicated-test/rasa-demo:run$BUILD_NUMBER
+      - name: Build Image
+        run: |
+          docker build -t gcr.io/replicated-test/rasa-demo:run$BUILD_NUMBER -t gcr.io/replicated-test/rasa-demo:latest --cache-from gcr.io/replicated-test/rasa-demo:latest .
+      
+      - name: Push PR Image to Google Cloud Container Registry
+        run: |
+          docker push gcr.io/replicated-test/rasa-demo:run$BUILD_NUMBER

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -1,0 +1,42 @@
+name: Continuous Integration
+on:
+  push:
+    branches:
+    - master
+
+jobs:
+  docker:
+    name: Build Action Server Docker Image
+    runs-on: ubuntu-latest
+
+    env:
+      DOCKERHUB_USERNAME: oakela
+
+    steps:
+      - name: Checkout git repository 🕝
+        uses: actions/checkout@v2
+
+        - name: Authenticate into Google Cloud Platform
+        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        with:
+          version: '275.0.0'
+          service_account_key: ${{ secrets.GCLOUD_AUTH }}
+
+        - name: Configure Docker to use Google Cloud Platform
+          run: |
+            gcloud auth configure-docker
+
+        - name: Pull Latest Image
+          run: |
+            docker pull gcr.io/replicated-test/rasa-demo:latest || true
+
+        - name: Set Build ID from PR Ref
+          run: echo ::set-env name=BUILD_NUMBER::$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+
+        - name: Build Image
+          run: |
+            docker build -t gcr.io/replicated-test/rasa-demo:pr$BUILD_NUMBER -t gcr.io/replicated-test/rasa-demo:latest --cache-from gcr.io/replicated-test/rasa-demo:latest .
+        
+        - name: Push PR Image to Google Cloud Container Registry
+          run: |
+            docker push gcr.io/replicated-test/rasa-demo:pr$BUILD_NUMBER

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -3,14 +3,13 @@ on:
   push:
     branches:
     - master
+    paths:
+    - 'actions/**'
 
 jobs:
   docker:
     name: Build Action Server Docker Image
     runs-on: ubuntu-latest
-
-    env:
-      DOCKERHUB_USERNAME: oakela
 
     steps:
       - name: Checkout git repository 🕝
@@ -30,13 +29,13 @@ jobs:
           run: |
             docker pull gcr.io/replicated-test/rasa-demo:latest || true
 
-        - name: Set Build ID from PR Ref
-          run: echo ::set-env name=BUILD_NUMBER::$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+        - name: Set Build ID from run ID and number
+          run: echo ::set-env name=BUILD_NUMBER::$GITHUB_RUN_NUMBER-$GITHUB_RUN_ID
 
         - name: Build Image
           run: |
-            docker build -t gcr.io/replicated-test/rasa-demo:pr$BUILD_NUMBER -t gcr.io/replicated-test/rasa-demo:latest --cache-from gcr.io/replicated-test/rasa-demo:latest .
+            docker build -t gcr.io/replicated-test/rasa-demo:run$BUILD_NUMBER -t gcr.io/replicated-test/rasa-demo:latest --cache-from gcr.io/replicated-test/rasa-demo:latest .
         
         - name: Push PR Image to Google Cloud Container Registry
           run: |
-            docker push gcr.io/replicated-test/rasa-demo:pr$BUILD_NUMBER
+            docker push gcr.io/replicated-test/rasa-demo:run$BUILD_NUMBER

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -39,5 +39,4 @@ jobs:
       
       - name: Push PR Image to Google Cloud Container Registry
         run: |
-          docker push gcr.io/replicated-test/rasa-demo:run$BUILD_NUMBER
-          docker push gcr.io/replicated-test/rasa-demo:latest
+          docker push gcr.io/replicated-test/rasa-demo

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -5,6 +5,7 @@ on:
     - master
     paths:
     - 'actions/**'
+    - 'Dockerfile'
 
 jobs:
   docker:

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -40,3 +40,4 @@ jobs:
       - name: Push PR Image to Google Cloud Container Registry
         run: |
           docker push gcr.io/replicated-test/rasa-demo:run$BUILD_NUMBER
+          docker push gcr.io/replicated-test/rasa-demo:latest


### PR DESCRIPTION
Closes https://github.com/RasaHQ/rasa-demo/issues/501
Action server image will only be pushed on push to master.
Image will be tagged with `run$GITHUB_NUMBER-$GITHUB_RUN_ID` (as well as `latest`)

Reason for the tag change:
Push to master is not guaranteed to be a PR, so we can't always use `pr...`. GITHUB_NUMBER provides an easy way to see what was the latest build since it increments by run, GITHUB_RUN_ID makes it easy to find the run (and therefore commit) that triggered the run since that's what's in a run's URL.