### PR TITLE
replace setenv commands

### DIFF
--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -38,7 +38,7 @@ jobs:
           || contains(  steps.files.outputs.all, 'domain.yml' )
       run: echo "RUN_TRAINING=true" >> $GITHUB_ENV
     - name: Set up Python 3.7
-      if: env.RUN_TRAINING == 'true' 
+      if: env.RUN_TRAINING == 'true'
       uses: actions/setup-python@v1
       with:
         python-version: 3.7

--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -36,9 +36,9 @@ jobs:
           contains(  steps.files.outputs.all, 'data/' )
           || contains(  steps.files.outputs.all, 'config.yml' )
           || contains(  steps.files.outputs.all, 'domain.yml' )
-      run: echo "::set-env name=RUN_TRAINING::true"
+      run: echo "RUN_TRAINING=true" >> $GITHUB_ENV
     - name: Set up Python 3.7
-      if: env.RUN_TRAINING == 'true'
+      if: env.RUN_TRAINING == 'true' 
       uses: actions/setup-python@v1
       with:
         python-version: 3.7

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -67,7 +67,7 @@ jobs:
           contains(  steps.files.outputs.all, 'data/' ) 
           || contains(  steps.files.outputs.all, 'config.yml' ) 
           || contains(  steps.files.outputs.all, 'domain.yml' )
-      run: echo "::set-env name=RUN_TRAINING::true"
+      run: echo "RUN_TRAINING=true"  >> $GITHUB_ENV
     - name: Set up Python 3.7
       if: env.RUN_TRAINING == 'true'
       uses: actions/setup-python@v1
@@ -132,7 +132,7 @@ jobs:
       if: |
         contains(  steps.files.outputs.all, 'actions/' ) 
         || contains(  steps.files.outputs.all, 'Dockerfile' )
-      run: echo "::set-env name=ACTIONS_CHANGED::true"
+      run: echo "ACTIONS_CHANGED=true" >> $GITHUB_ENV
     - name: Authenticate into Google Cloud Platform
       if: env.ACTIONS_CHANGED == 'true'
       uses: GoogleCloudPlatform/github-actions/setup-gcloud@master

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -31,7 +31,7 @@ jobs:
           docker pull gcr.io/replicated-test/rasa-demo:latest || true
 
       - name: Set Build ID from run ID and number
-        run: echo ::set-env name=BUILD_NUMBER::$GITHUB_RUN_NUMBER-$GITHUB_RUN_ID
+        run: echo "BUILD_NUMBER=$GITHUB_RUN_NUMBER-$GITHUB_RUN_ID" >> $GITHUB_ENV
 
       - name: Build Image
         run: |


### PR DESCRIPTION
Replace deprecated set-env commands in CI because of https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/