### PR TITLE
change default branch name to main

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -114,9 +114,9 @@ jobs:
         rasa test core --stories test/test_stories.md --fail-on-prediction-errors
     - name: Upload model
       if: |
-          github.ref == 'refs/heads/master' 
+          github.ref == 'refs/heads/main'
           && env.RUN_TRAINING == 'true'
-      uses: actions/upload-artifact@master
+      uses: actions/upload-artifact@main
       with:
         name: model
         path: models

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -22,7 +22,7 @@ jobs:
           version: '275.0.0'
           service_account_key: ${{ secrets.GCLOUD_AUTH }}
 
-      - name: Configure Docker to use Google Cloud Platform
+      - name: Configure Docker to use Google Cloud Platform ☁️
         run: |
           gcloud auth configure-docker
 

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -2,7 +2,7 @@ name: Continuous Integration
 on:
   push:
     branches:
-    - master
+    - main
     paths:
     - 'actions/**'
     - 'Dockerfile'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # Sara - the Rasa Demo Bot
-[![Build Status](https://travis-ci.com/RasaHQ/rasa-demo.svg?branch=master)](https://travis-ci.com/RasaHQ/rasa-demo)
 
 ## :surfer: Introduction
 The purpose of this repo is to showcase a contextual AI assistant built with the open source Rasa framework.
@@ -96,5 +95,5 @@ black .
 
 ## :gift: License
 Licensed under the GNU General Public License v3. Copyright 2018 Rasa Technologies
-GmbH. [Copy of the license](https://github.com/RasaHQ/rasa-demo/blob/master/LICENSE).
+GmbH. [Copy of the license](https://github.com/RasaHQ/rasa-demo/blob/main/LICENSE).
 Licensees may convey the work under this license. There is no warranty for the work.

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     maintainer_email="akela@rasa.com",
     license="GNU General Public License v3.0",
     url="https://github.com/rasahq/rasa-demo",
-    download_url="https://github.com/RasaHQ/rasa-demo/archive/master.zip",
+    download_url="https://github.com/RasaHQ/rasa-demo/archive/main.zip",
     project_urls={
         "Bug Reports": "https://github.com/rasahq/rasa-demo/issues",
         "Source": "https://github.com/rasahq/rasa-demo",


### PR DESCRIPTION
Change workflows to work on `main` branch. 

Also updated the github actions we use as their default branches' names were changed: 
* https://github.com/actions/upload-artifact

Still to do: 
- [ ] Update target branch of any deployed instances that connect to this bot
- [ ] Update any docs/blogs that link to sara