### PR TITLE
Add NLU training examples for ask_when_next_event

### DIFF
--- a/data/nlu/chitchat.yml
+++ b/data/nlu/chitchat.yml
@@ -830,3 +830,18 @@ nlu:
     - who am i
     - who are I ?
     - who may i ?
+- intent: ask_when_next_event
+  examples: |
+    - When will be the next event ?
+    - When is the next event in [Berlin](location)?
+    - Hi is there an upcoming event ?
+    - when is the next event
+    - is there a event in [mexico](location)
+    - is there a event in berlin
+    - when is the next event in [Berlin](location)
+    - whein is the next community event in [berlin](location)
+    - when is the next community event
+    - when is the next event planned in [Sweden](location) ?
+    - when is the next events in [Montreal](location)?
+    - when is the next event in [New York](location)?
+    - when is the next rasa event


### PR DESCRIPTION
This intent wasn't previously covered in the training data; I now added a few real examples from the NLU inbox.