### PR TITLE
Move tagging to RasaXAPI class

### DIFF
--- a/actions/actions.py
+++ b/actions/actions.py
@@ -22,6 +22,7 @@ from actions.api.algolia import AlgoliaAPI
 from actions.api.discourse import DiscourseAPI
 from actions.api.gdrive_service import GDriveService
 from actions.api.mailchimp import MailChimpAPI
+from actions.api.rasaxapi import RasaXAPI
 
 logger = logging.getLogger(__name__)
 
@@ -774,13 +775,6 @@ class ActionForumSearch(Action):
         return []
 
 
-def tag_convo(tracker: Tracker, label: Text) -> None:
-    """Tag a conversation in Rasa X with a given label"""
-    endpoint = f"http://{config.rasa_x_host}/api/conversations/{tracker.sender_id}/tags"
-    requests.post(url=endpoint, data=label)
-    return
-
-
 class ActionTagFeedback(Action):
     """Tag a conversation in Rasa X as positive or negative feedback """
 
@@ -803,7 +797,7 @@ class ActionTagFeedback(Action):
         else:
             return []
 
-        tag_convo(tracker, label)
+        RasaXAPI.tag_convo(tracker, label)
 
         return []
 
@@ -829,6 +823,6 @@ class ActionTagDocsSearch(Action):
         else:
             return []
 
-        tag_convo(tracker, label)
+        RasaXAPI.tag_convo(tracker, label)
 
         return []

--- a/actions/api/rasaxapi.py
+++ b/actions/api/rasaxapi.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+from typing import Text
+import requests
+import logging
+
+from rasa_sdk import Tracker
+
+from actions import config
+
+logger = logging.getLogger(__name__)
+
+
+class RasaXAPI:
+    """Class to connect to the Rasa X API"""
+    schema = config.rasa_x_host_schema
+    host = config.rasa_x_host
+    username = config.rasa_x_username
+    password = config.rasa_x_password
+
+    @classmethod
+    def get_auth_header(cls):
+        """
+        get authorization header with bearer token if authentication succeeds
+        """
+        url = f"{cls.schema}://{cls.host}/api/auth"
+        payload = {"username": cls.username, "password": cls.password}
+        response = requests.post(url, json=payload)
+        try:
+            authtoken = response.json()["access_token"]
+            header = {"Authorization": f"Bearer {authtoken}"}
+            return header
+        except:
+            return {}
+
+    @classmethod
+    def tag_convo(cls, tracker: Tracker, label: Text) -> None:
+        """Tag a conversation in Rasa X with a given label"""
+        auth_header = cls.get_auth_header()
+        endpoint = f"{cls.schema}://{cls.host}/api/conversations/{tracker.sender_id}/tags"
+        response = requests.post(url=endpoint, data = label, headers=auth_header)
+        return response

--- a/actions/config.py
+++ b/actions/config.py
@@ -1,40 +1,10 @@
 import os
 
-policy_model_dir = os.environ.get("POLICY_MODEL_DIR", "models/dialogue/")
-
-rasa_nlu_config = os.environ.get("RASA_NLU_CONFIG", "nlu_config.yml")
-
-account_sid = os.environ.get("ACCOUNT_SID", "")
-
-auth_token = os.environ.get("AUTH_TOKEN", "")
-
-twilio_number = os.environ.get("TWILIO_NUMBER", "")
-
-platform_api = os.environ.get("RASA_API_ENDPOINT_URL", "")
-
-self_port = int(os.environ.get("SELF_PORT", "5001"))
-
-core_model_dir = os.environ.get("CORE_MODEL_DIR", "models/dialogue/")
-
-remote_core_endpoint = os.environ.get("RASA_REMOTE_CORE_ENDPOINT_URL", "")
-
-rasa_core_token = os.environ.get("RASA_CORE_TOKEN", "")
-
 mailchimp_api_key = os.environ.get("MAILCHIMP_API_KEY", "")
 
 mailchimp_list = os.environ.get("MAILCHIMP_LIST", "")
 
 gdrive_credentials = os.environ.get("GDRIVE_CREDENTIALS", "")
-
-access_token = os.environ.get("TELEGRAM_TOKEN", "")
-
-verify = os.environ.get("TELEGRAM_VERIFY", "rasas_bot")
-
-webhook_url = os.environ.get("WEBHOOK_URL", "https://website-demo.rasa.com/webhook")
-
-rasa_platform_token = os.environ.get("RASA_PLATFORM_TOKEN", "")
-
-rasa_nlg_endpoint = os.environ.get("RASA_NLG_ENDPOINT_URL", "")
 
 algolia_app_id = os.environ.get("ALGOLIA_APP_ID", "")
 
@@ -43,3 +13,9 @@ algolia_search_key = os.environ.get("ALGOLIA_SEARCH_KEY", "")
 algolia_docs_index = os.environ.get("ALGOLIA_DOCS_INDEX", "")
 
 rasa_x_host = os.environ.get("RASA_X_HOST", "rasa-x:5002")
+
+rasa_x_password = os.environ.get("RASA_X_PASSWORD", "")
+
+rasa_x_username = os.environ.get("RASA_X_USERNAME", "")
+
+rasa_x_host_schema = os.environ.get("RASA_X_HOST_SCHEMA", "http")


### PR DESCRIPTION
- Create a  class for connecting to Rasa X and use this for tagging conversations.
- Remove unused config variables


This came up during creating unit tests -  the Rasa X API is the only one we connect to without a dedicated class, and it is more extendable in a class than in separate methods. 