### PR TITLE
Set less requests for rasa worker so it gets scheduled on node with memory tag

### DIFF
--- a/.github/deployments/values/default.yaml
+++ b/.github/deployments/values/default.yaml
@@ -7,8 +7,8 @@ rasaProduction:
 rasaWorker:
   resources:
     requests:
-      memory: 6Gi
-      cpu: 4
+      memory: 4Gi
+      cpu: 2
 rasax:
   resources:
     requests:


### PR DESCRIPTION
* Lowers the CPU/memory requests for rasa-worker so that a second pod can be scheduled on the single extra-memory node in the cluster
The node's label ensures rasa-worker still gets scheduled only on a high memory node.

It was often failing to schedule the node since the existing requests would not leave quite enough for a second pod with the same requirements. 