### PR TITLE
assume there are no events if html tag not found

### DIFF
--- a/actions/api/algolia.py
+++ b/actions/api/algolia.py
@@ -4,7 +4,7 @@ from typing import Text, List
 
 import spacy
 
-en_spacy = spacy.load("en")
+en_spacy = spacy.load("en_core_web_md")
 
 additional_stopwords = {"need", "want", "help", "able", "unable", "know", "use"}
 STOPWORDS = spacy.lang.en.stop_words.STOP_WORDS.union(additional_stopwords)

--- a/actions/api/community_events.py
+++ b/actions/api/community_events.py
@@ -78,8 +78,12 @@ def get_community_events() -> List["CommunityEvent"]:
         community_page = response.content
 
         soup = BeautifulSoup(community_page, "html.parser")
+        potential_events = soup.find("ul", attrs={"id": "events-list"})
+        if potential_events:
+            events = potential_events.find_all("li")
+        else:
+            events = []
 
-        events = soup.find("ul", attrs={"id": "events-list"}).find_all("li")
         parsed_events = [CommunityEvent.from_html(e) for e in events]
 
         now = datetime.date.today()


### PR DESCRIPTION
Currently there are no events posted on the events page, the html tag is not found and therefore the action errors out.

This PR hot-fixes it by assuming when the tag is not found, there are no events. 
